### PR TITLE
WIP experimental pointwise dot() for powerlaw Legendre

### DIFF
--- a/src/ClassicalOrthogonalPolynomials.jl
+++ b/src/ClassicalOrthogonalPolynomials.jl
@@ -10,7 +10,7 @@ import Base: @_inline_meta, axes, getindex, convert, prod, *, /, \, +, -,
 import Base.Broadcast: materialize, BroadcastStyle, broadcasted
 import LazyArrays: MemoryLayout, Applied, ApplyStyle, flatten, _flatten, colsupport, adjointlayout,
                 sub_materialize, arguments, sub_paddeddata, paddeddata, PaddedLayout, resizedata!, LazyVector, ApplyLayout, call,
-                _mul_arguments, CachedVector, CachedMatrix, LazyVector, LazyMatrix, axpy!, AbstractLazyLayout, BroadcastLayout, AbstractCachedVector
+                _mul_arguments, CachedVector, CachedMatrix, LazyVector, LazyMatrix, axpy!, AbstractLazyLayout, BroadcastLayout, AbstractCachedVector, AbstractCachedMatrix
 import ArrayLayouts: MatMulVecAdd, materialize!, _fill_lmul!, sublayout, sub_materialize, lmul!, ldiv!, ldiv, transposelayout, triangulardata
 import LinearAlgebra: pinv, factorize, qr, adjoint, transpose, dot
 import BandedMatrices: AbstractBandedLayout, AbstractBandedMatrix, _BandedMatrix, bandeddata

--- a/src/ClassicalOrthogonalPolynomials.jl
+++ b/src/ClassicalOrthogonalPolynomials.jl
@@ -12,7 +12,7 @@ import LazyArrays: MemoryLayout, Applied, ApplyStyle, flatten, _flatten, colsupp
                 sub_materialize, arguments, sub_paddeddata, paddeddata, PaddedLayout, resizedata!, LazyVector, ApplyLayout, call,
                 _mul_arguments, CachedVector, CachedMatrix, LazyVector, LazyMatrix, axpy!, AbstractLazyLayout, BroadcastLayout, AbstractCachedVector
 import ArrayLayouts: MatMulVecAdd, materialize!, _fill_lmul!, sublayout, sub_materialize, lmul!, ldiv!, ldiv, transposelayout, triangulardata
-import LinearAlgebra: pinv, factorize, qr, adjoint, transpose
+import LinearAlgebra: pinv, factorize, qr, adjoint, transpose, dot
 import BandedMatrices: AbstractBandedLayout, AbstractBandedMatrix, _BandedMatrix, bandeddata
 import FillArrays: AbstractFill, getindex_value
 

--- a/src/jacobi.jl
+++ b/src/jacobi.jl
@@ -197,11 +197,20 @@ end
 ########
 
 jacobimatrix(::Legendre{T}) where T = _BandedMatrix(Vcat(((zero(T):∞)./(1:2:∞))', Zeros{T}(1,∞), ((one(T):∞)./(1:2:∞))'), ∞, 1,1)
+function jacobimatrix(Q::Normalized{<:Any,<:Legendre})
+    b = (1:∞) ./sqrt.(4 .*(1:∞).^2 .-1)
+    Symmetric(_BandedMatrix(Vcat(zeros(∞)', (b)'), ∞, 1, 0), :L)
+end
 
 # These return vectors A[k], B[k], C[k] are from DLMF. Cause of MikaelSlevinsky we need an extra entry in C ... for now.
 function recurrencecoefficients(::Legendre{T}) where T
     n = zero(T):∞
     ((2n .+ 1) ./ (n .+ 1), Zeros{T}(∞), n ./ (n .+ 1))
+end
+function recurrencecoefficients(::Normalized{<:Any,<:Legendre{T}}) where T
+    n = zero(T):∞
+    nn = one(T):∞
+    ((2n .+ 1) ./ (n .+ 1) ./ sqrt.(1 .-2 ./(3 .+2n)), Zeros{T}(∞), Vcat(zero(T),nn ./ (nn .+ 1) ./ sqrt.(1 .-4 ./(3 .+2nn))))
 end
 
 function jacobimatrix(J::Jacobi)
@@ -213,7 +222,6 @@ function jacobimatrix(J::Jacobi)
 
     _BandedMatrix(Vcat(C',A',B'), ∞, 1,1)
 end
-
 function recurrencecoefficients(P::Jacobi)
     n = 0:∞
     ñ = 1:∞

--- a/src/jacobi.jl
+++ b/src/jacobi.jl
@@ -197,7 +197,7 @@ end
 ########
 
 jacobimatrix(::Legendre{T}) where T = _BandedMatrix(Vcat(((zero(T):∞)./(1:2:∞))', Zeros{T}(1,∞), ((one(T):∞)./(1:2:∞))'), ∞, 1,1)
-function jacobimatrix(Q::Normalized{<:Any,<:Legendre})
+function jacobimatrix(::Normalized{<:Any,<:Legendre})
     b = (1:∞) ./sqrt.(4 .*(1:∞).^2 .-1)
     Symmetric(_BandedMatrix(Vcat(zeros(∞)', (b)'), ∞, 1, 0), :L)
 end

--- a/src/stieltjes.jl
+++ b/src/stieltjes.jl
@@ -86,72 +86,31 @@ const PowKernelPoint{T,V,D,F} =  BroadcastQuasiVector{T, typeof(^), Tuple{Contin
 # cached operator implementation
 ####
 # Constructors support BigFloat and it's recommended to use them for high orders.
-mutable struct PowerLawIntegral{T, PP<:AbstractQuasiMatrix} <: AbstractCachedMatrix{T}
-    P::PP # OPs - only Legendre supported for now
-    a::T  # naming scheme follows (t-x)^a
-    t::T
-    data::Matrix{T}
-    datasize::Tuple{Int,Int}
-    array
-    function PowerLawIntegral{T, PP}(P::PP, a::T, t::T) where {T, PP<:AbstractQuasiMatrix}
-        new{T, PP}(P,a,t, pointwisecoeffmatrixdense(a,t,10),(10,10))
-    end
-end
-PowerLawIntegral(P::AbstractQuasiMatrix, a::T, t::T) where T = PowerLawIntegral{T,typeof(P)}(P,a,t)
-size(K::PowerLawIntegral) = (∞,∞) # potential to add maximum size of operator
-mutable struct PowerLawMatrix{T, PP<:AbstractQuasiMatrix} <: AbstractCachedMatrix{T}
-    P::PP # OPs - only Legendre supported for now
+mutable struct PowerLawMatrix{T, PP<:Normalized{<:Any,<:Legendre{<:Any}}} <: AbstractCachedMatrix{T}
+    P::PP # OPs - only normalized Legendre supported for now
     a::T  # naming scheme follows (t-x)^a
     t::T
     data::Matrix{T}
     datasize::Tuple{Int,Int}
     array
     function PowerLawMatrix{T, PP}(P::PP, a::T, t::T) where {T, PP<:AbstractQuasiMatrix}
-        new{T, PP}(P,a,t, pointwisecoeffmatrixdense(a,t,10),(10,10))
+        new{T, PP}(P,a,t, gennormalizedpower(a,t,10),(10,10))
     end
 end
 PowerLawMatrix(P::AbstractQuasiMatrix, a::T, t::T) where T = PowerLawMatrix{T,typeof(P)}(P,a,t)
 size(K::PowerLawMatrix) = (∞,∞) # potential to add maximum size of operator
 
 # data filling
-cache_filldata!(K::PowerLawIntegral, inds) = fillcoeffmatrix!(K, inds)
 cache_filldata!(K::PowerLawMatrix, inds) = fillcoeffmatrix!(K, inds)
 
 # because it really only makes sense to compute this symmetric operator in square blocks, we have to slightly rework some of LazyArrays caching and resizing
-function getindex(K::PowerLawIntegral{T, PP}, I::CartesianIndex) where {T,PP<:AbstractQuasiMatrix}
+function getindex(K::PowerLawMatrix{T, PP}, I::CartesianIndex) where {T,PP<:AbstractQuasiMatrix}
     resizedata!(K, Tuple(I))
     K.data[I]
 end
-function getindex(K::PowerLawIntegral{T,PP}, I::Vararg{Int,2}) where {T,PP<:AbstractQuasiMatrix}
-    resizedata!(K, Tuple([I...]))
-    K.data[I...]
-end
-function getindex(K::PowerLawMatrix{T, PP}, I::CartesianIndex) where {T,PP<:AbstractQuasiMatrix}
-    resizedata!(K, Tuple(I))
-    ℓ = K.datasize[1]
-    return (InfiniteArrays.Diagonal((2 .* (0:ℓ-1) .+1)/2)*(K.data))[I]
-end
 function getindex(K::PowerLawMatrix{T,PP}, I::Vararg{Int,2}) where {T,PP<:AbstractQuasiMatrix}
     resizedata!(K, Tuple([I...]))
-    ℓ = K.datasize[1]
-    return (InfiniteArrays.Diagonal((2 .* (0:ℓ-1) .+1)/2)*(K.data))[I...]
-end
-function resizedata!(K::PowerLawIntegral, nm) 
-    olddata = K.data
-    νμ = size(olddata)
-    nm = (maximum(nm),maximum(nm))
-    nm = max.(νμ,nm)
-    nm = (maximum(nm),maximum(nm))
-    if νμ ≠ nm
-        K.data = similar(K.data, nm...)
-        K.data[axes(olddata)...] = olddata
-    end
-    if maximum(nm) > maximum(νμ)
-        inds = Array(maximum(νμ):maximum(nm))
-        cache_filldata!(K, inds)
-        K.datasize = nm
-    end
-    K
+    K.data[I...]
 end
 function resizedata!(K::PowerLawMatrix, nm) 
     olddata = K.data
@@ -174,12 +133,12 @@ end
 ####
 # methods
 ####
-function *(K::PowKernelPoint,Q::Legendre{T}) where T
+function *(K::PowKernelPoint,Q::Normalized{<:Any,<:Legendre{<:Any}})
     t = K.args[1][0.]
     a = K.args[2]
     return Q*PowerLawMatrix(Q,a,t)
 end
-function dot(f::AbstractVector{T}, K::PowerLawIntegral, g::AbstractVector{T}) where T
+function dot(f::AbstractVector{T}, K::PowerLawMatrix, g::AbstractVector{T}) where T
     (i,conv1,conv2) = (0,1,2)
     while abs(conv1-conv2)>1e-15
         i = i+1
@@ -188,7 +147,7 @@ function dot(f::AbstractVector{T}, K::PowerLawIntegral, g::AbstractVector{T}) wh
     end
     return conv2
 end
-function *(g::Adjoint, K::PowerLawIntegral, f::AbstractVector)
+function *(g::Adjoint, K::PowerLawMatrix, f::AbstractVector)
     return dot(g',K,f)
 end
 
@@ -197,52 +156,56 @@ end
 ####
 # this function evaluates the recurrence and returns the full operator. 
 # We don't use this outside of the initial block.
-function pointwisecoeffmatrixdense(a::Real, t::Real, ℓ::Integer)
+function gennormalizedpower(a::Real, t::Real, ℓ::Integer)
     # initialization
-    ℓ = ℓ+1
+    ℓ = ℓ+3
     coeff = convert.(typeof(a),zeros(ℓ,ℓ))
     # load in explicit initial cases
-    coeff[1,1] = PLinitial00(t,a)
-    coeff[1,2] = PLinitial01(t,a)
-    coeff[2,2] = PLinitial11(t,a)
-    coeff[2,3] = PLinitial12(t,a)
+    coeff[1,1] = PLnorminitial00(t,a)
+    coeff[1,2] = PLnorminitial01(t,a)
+    coeff[2,2] = PLnorminitial11(t,a)
+    coeff[2,3] = PLnorminitial12(t,a)
     # we have to build these two cases with some care
-    coeff[1,3] = t/((a+3)/3)*coeff[1,2]+(a/3)/((a+3)/3)*coeff[1,1]
-    m=1
-    coeff[3,m+2] = t/((m+1)*(a+m+4)/((2*m+1)*(m+3)))*coeff[m+1,3]+((a+1)*2/(6-m*(m+1)))/((m+1)*(a+m+4)/((2*m+1)*(m+3)))*coeff[2,m+1]-(m*(a+3-m)/((2*m+1)*(2-m)))*1/((m+1)*(a+m+4)/((2*m+1)*(m+3)))*coeff[m,3]
-    # the remaining cases can be constructed iteratively
+    coeff[1,3] = t/((a+3)/3)*normconst_Pnadd1(1)*coeff[1,2]+(a/3)/((a+3)/3)*normconst_Pnsub1(1)*coeff[1,1]
+    #the remaining cases can be constructed iteratively
     @inbounds for m = 2:ℓ-2
         # first row
-        coeff[1,m+2] = (t/((a+m+2)/(2*m+1))*coeff[1,m+1]+((a-m+1)/(2*m+1))/((a+m+2)/(2*m+1))*coeff[1,m])
+        coeff[1,m+2] = (t/((a+m+2)/(2*m+1))*normconst_Pnadd1(m)*coeff[1,m+1]+((a-m+1)/(2*m+1))/((a+m+2)/(2*m+1))*normconst_Pnsub1(m)*coeff[1,m])
         # second row
-        coeff[2,m+2] = (t/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*coeff[2,m+1]+((a+1)/(2-m*(m+1)))/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*coeff[1,m+1]-(m*(a+2-m)/((2*m+1)*(1-m)))*1/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*coeff[2,m])
+        coeff[2,m+2] = (t/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*normconst_Pnadd1(m)*coeff[2,m+1]+((a+1)/(2-m*(m+1)))/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*normconst_Pmnmix(1,m)*coeff[1,m+1]-(m*(a+2-m)/((2*m+1)*(1-m)))*1/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*normconst_Pnsub1(m)*coeff[2,m])
         # build remaining row elements
         @inbounds for j=1:m-1
-            n = j
-            coeff[j+2,m+1] = (t/((n+1)*(a+m+n+2)/((2*n+1)*(m+n+1)))*coeff[n+1,m+1]+((a+1)*m/(m*(m+1)-n*(n+1)))/((n+1)*(a+m+n+2)/((2*n+1)*(m+n+1)))*coeff[n+1,m]-(n*(a+m-n+1)/((2*n+1)*(m-n)))*1/((n+1)*(a+m+n+2)/((2*n+1)*(m+n+1)))*coeff[n,m+1])
+            coeff[j+2,m+1] = (t/((j+1)*(a+m+j+2)/((2*j+1)*(m+j+1)))*normconst_Pnadd1(j)*coeff[j+1,m+1]+((a+1)*m/(m*(m+1)-j*(j+1)))/((j+1)*(a+m+j+2)/((2*j+1)*(m+j+1)))*normconst_Pmnmix(m,j)*coeff[j+1,m]-(j*(a+m-j+1)/((2*j+1)*(m-j)))*1/((j+1)*(a+m+j+2)/((2*j+1)*(m+j+1)))*normconst_Pnsub1(j)*coeff[j,m+1])
         end
     end
-    # matrix is symmetric
+    #matrix is symmetric
     @inbounds for m=1:ℓ
         @inbounds for n=m+1:ℓ
             coeff[n,m] = coeff[m,n]
         end
     end
-    return coeff[1:ℓ-1,1:ℓ-1]
+    return coeff[1:ℓ-3,1:ℓ-3]
 end
+
+# modify recurrence coefficients to work for normalized Legendre
+# TODO: should probably use whatever type is being asked for instead of defaulting to BigFloat
+normconst_Pnadd1(m) = sqrt(2*BigInt(m)+3)/sqrt(2*BigInt(m)+1)
+normconst_Pnsub1(m) = sqrt(2*BigInt(m)+3)/sqrt(2*BigInt(m)-1)
+normconst_Pmnmix(n,m) = sqrt(2*BigInt(m)+3)*sqrt(2*BigInt(n)+1)/(sqrt(2*BigInt(m)+1)*sqrt(2*BigInt(n)-1))
 # these explicit initial cases are needed to kick off the recurrence
-function PLinitial00(t, a)
-    return ((t+1)^(a+1)-(t-1)^(a+1))/(a+1)
+function PLnorminitial00(t, a)
+    return ((t+1)^(a+1)-(t-1)^(a+1))/(2*(a+1))
 end
-function PLinitial01(t, a)
-    return ((t+1)^(a+1)*(-a+t-1)-(a+t+1)*(t-1)^(a+1))/((a+1)*(a+2))
+function PLnorminitial01(t, a)
+    return sqrt(BigInt(3))*((t+1)^(a+1)*(-a+t-1)-(a+t+1)*(t-1)^(a+1))/(2*(a+1)*(a+2))
 end
-function PLinitial11(t, a)
-    return ((t+1)^(a+1)*(a^2+a*(3-2*t)+2*(t-1)*t+2)-(t-1)^(a+1)*(a^2+a*(2*t+3)+2*(t^2+t+1)))/((a+1)*(a+2)*(a+3))
+function PLnorminitial11(t, a)
+    return BigInt(3)*((t+1)^(a+1)*(a^2+a*(3-2*t)+2*(t-1)*t+2)-(t-1)^(a+1)*(a^2+a*(2*t+3)+2*(t^2+t+1)))/(2*(a+1)*(a+2)*(a+3))
 end
-function PLinitial12(t, a)
-    return -(((1+t)^(1+a)*((1+a)^2*(3+a)-(3+2*a*(5+2*a))*t+9*(1+a)*t^2-9*t^3)+(-1+t)^(1+a)*((1+a)^2*(3+a)+(3+2*a*(5+2*a))*t+9*(1+a)*t^2+9*t^3))/((1+a)*(2+a)*(3+a)*(4+a)))
+function PLnorminitial12(t, a)
+    return -sqrt(BigInt(15))*(((1+t)^(1+a)*((1+a)^2*(3+a)-(3+2*a*(5+2*a))*t+9*(1+a)*t^2-9*t^3)+(-1+t)^(1+a)*((1+a)^2*(3+a)+(3+2*a*(5+2*a))*t+9*(1+a)*t^2+9*t^3))/(2*(1+a)*(2+a)*(3+a)*(4+a)))
 end
+
 # the following version takes a previously computed block that has been resized and fills in the missing data guided by indices in inds
 function fillcoeffmatrix!(K, inds)
     # the remaining cases can be constructed iteratively
@@ -251,13 +214,12 @@ function fillcoeffmatrix!(K, inds)
     @inbounds for m in inds
         m=m-2
         # first row
-        K.data[1,m+2] = (t/((a+m+2)/(2*m+1))*K.data[1,m+1]+((a-m+1)/(2*m+1))/((a+m+2)/(2*m+1))*K.data[1,m])
+        K.data[1,m+2] = (t/((a+m+2)/(2*m+1))*normconst_Pnadd1(m)*K.data[1,m+1]+((a-m+1)/(2*m+1))/((a+m+2)/(2*m+1))*normconst_Pnsub1(m)*K.data[1,m])
         # second row
-        K.data[2,m+2] = (t/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*K.data[2,m+1]+((a+1)/(2-m*(m+1)))/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*K.data[1,m+1]-(m*(a+2-m)/((2*m+1)*(1-m)))*1/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*K.data[2,m])
+        K.data[2,m+2] = (t/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*normconst_Pnadd1(m)*K.data[2,m+1]+((a+1)/(2-m*(m+1)))/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*normconst_Pmnmix(1,m)*K.data[1,m+1]-(m*(a+2-m)/((2*m+1)*(1-m)))*1/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*normconst_Pnsub1(m)*K.data[2,m])
         # build remaining row elements
         @inbounds for j=1:m
-            n = j
-            K.data[j+2,m+2] = (t/((n+1)*(a+m+1+n+2)/((2*n+1)*(m+1+n+1)))*K.data[n+1,m+2]+((a+1)*(m+1)/((m+1)*(m+2)-n*(n+1)))/((n+1)*(a+m+1+n+2)/((2*n+1)*(m+1+n+1)))*K.data[n+1,m+1]-(n*(a+m+1-n+1)/((2*n+1)*(m+1-n)))*1/((n+1)*(a+m+1+n+2)/((2*n+1)*(m+1+n+1)))*K.data[n,m+2])
+            K.data[j+2,m+2] = (t/((j+1)*(a+m+1+j+2)/((2*j+1)*(m+1+j+1)))*normconst_Pnadd1(j)*K.data[j+1,m+2]+((a+1)*(m+1)/((m+1)*(m+2)-j*(j+1)))/((j+1)*(a+m+1+j+2)/((2*j+1)*(m+j+2)))*normconst_Pmnmix(m,j)*K.data[j+1,m+1]-(j*(a+m+1-j+1)/((2*j+1)*(m+1-j)))*1/((j+1)*(a+m+1+j+2)/((2*j+1)*(m+1+j+1)))*normconst_Pnsub1(j)*K.data[j,m+2])
         end
     end
     # matrix is symmetric

--- a/src/stieltjes.jl
+++ b/src/stieltjes.jl
@@ -130,10 +130,7 @@ PowerLawIntegral(P::AbstractQuasiMatrix, a::T, t::T) where T = PowerLawIntegral{
 size(K::PowerLawIntegral) = (∞,∞) # potential to add maximum size of operator
 
 # data filling
-function _legendrepowerlaw_fill_data!(K::PowerLawIntegral, inds)
-    fillcoeffmatrix!(K, inds)
-end
-cache_filldata!(K::PowerLawIntegral, inds) = _legendrepowerlaw_fill_data!(K, inds)
+cache_filldata!(K::PowerLawIntegral, inds) = fillcoeffmatrix!(K, inds)
 
 # because it really only makes sense to compute this symmetric operator in square blocks, we have to slightly rework some of LazyArrays caching and resizing
 function Base.getindex(A::PowerLawIntegral{T, PP}, I::CartesianIndex) where {T,PP<:AbstractQuasiMatrix}

--- a/src/stieltjes.jl
+++ b/src/stieltjes.jl
@@ -138,18 +138,6 @@ function *(K::PowKernelPoint,Q::Normalized{<:Any,<:Legendre{<:Any}})
     a = K.args[2]
     return Q*PowerLawMatrix(Q,a,t)
 end
-function dot(f::AbstractVector{T}, K::PowerLawMatrix, g::AbstractVector{T}) where T
-    (i,conv1,conv2) = (0,1,2)
-    while abs(conv1-conv2)>1e-15
-        i = i+1
-        conv1 = dot(f[1:i*10],K[1:i*10,1:i*10],g[1:i*10])
-        conv2 = dot(f[1:i*20],K[1:i*20,1:i*20],g[1:i*20])
-    end
-    return conv2
-end
-function *(g::Adjoint, K::PowerLawMatrix, f::AbstractVector)
-    return dot(g',K,f)
-end
 
 ####
 # recurrence evaluation
@@ -219,7 +207,7 @@ function fillcoeffmatrix!(K, inds)
         K.data[2,m+2] = (t/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*normconst_Pnadd1(m)*K.data[2,m+1]+((a+1)/(2-m*(m+1)))/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*normconst_Pmnmix(1,m)*K.data[1,m+1]-(m*(a+2-m)/((2*m+1)*(1-m)))*1/((m+1)*(a+m+3)/((2*m+1)*(m+2)))*normconst_Pnsub1(m)*K.data[2,m])
         # build remaining row elements
         @inbounds for j=1:m
-            K.data[j+2,m+2] = (t/((j+1)*(a+m+1+j+2)/((2*j+1)*(m+1+j+1)))*normconst_Pnadd1(j)*K.data[j+1,m+2]+((a+1)*(m+1)/((m+1)*(m+2)-j*(j+1)))/((j+1)*(a+m+1+j+2)/((2*j+1)*(m+j+2)))*normconst_Pmnmix(m,j)*K.data[j+1,m+1]-(j*(a+m+1-j+1)/((2*j+1)*(m+1-j)))*1/((j+1)*(a+m+1+j+2)/((2*j+1)*(m+1+j+1)))*normconst_Pnsub1(j)*K.data[j,m+2])
+            K.data[j+2,m+2] = (t/((j+1)*(a+m+1+j+2)/((2*j+1)*(m+1+j+1)))*normconst_Pnadd1(j)*K.data[j+1,m+2]+((a+1)*(m+1)/((m+1)*(m+2)-j*(j+1)))/((j+1)*(a+m+1+j+2)/((2*j+1)*(m+j+2)))*normconst_Pmnmix(m+1,j)*K.data[j+1,m+1]-(j*(a+m+1-j+1)/((2*j+1)*(m+1-j)))*1/((j+1)*(a+m+1+j+2)/((2*j+1)*(m+1+j+1)))*normconst_Pnsub1(j)*K.data[j,m+2])
         end
     end
     # matrix is symmetric

--- a/src/stieltjes.jl
+++ b/src/stieltjes.jl
@@ -80,7 +80,7 @@ end
 #################################################
 # ∫f(x)g(x)(t-x)^a dx evaluation where f and g in Legendre
 #################################################
-const PowKernelPoint{T,V,D,F} = BroadcastQuasiVector{T, typeof(^), Tuple{ContinuumArrays.AffineQuasiVector{T, V, Inclusion{V, D}, T}, F}}
+const PowKernelPoint{T, V, D, F} = BroadcastQuasiVector{T, typeof(^), Tuple{ContinuumArrays.AffineQuasiVector{T, V, Inclusion{V, D}, T}, F}}
 
 ############
 # METHODS
@@ -122,16 +122,16 @@ mutable struct PowerLawIntegral{T, PP<:AbstractQuasiMatrix} <: AbstractCachedMat
     datasize::Tuple{Int,Int}
     array
 
-    function PowerLawIntegral{T, PP}(P::PP,a::T,t::T) where {T,PP<:AbstractQuasiMatrix}
-        new{T, PP}(P,a,t, ClassicalOrthogonalPolynomials.pointwisecoeffmatrixdense(a,t,10),(10,10))
+    function PowerLawIntegral{T, PP}(P::PP, a::T, t::T) where {T, PP<:AbstractQuasiMatrix}
+        new{T, PP}(P,a,t, pointwisecoeffmatrixdense(a,t,10),(10,10))
     end
 end
-PowerLawIntegral(P::AbstractQuasiMatrix,a::T,t::T) where T = PowerLawIntegral{T,typeof(P)}(P,a,t)
+PowerLawIntegral(P::AbstractQuasiMatrix, a::T, t::T) where T = PowerLawIntegral{T,typeof(P)}(P,a,t)
 size(K::PowerLawIntegral) = (∞,∞) # potential to add maximum size of operator
 
 # data filling
 function _legendrepowerlaw_fill_data!(K::PowerLawIntegral, inds)
-    ClassicalOrthogonalPolynomials.fillcoeffmatrix!(K, inds)
+    fillcoeffmatrix!(K, inds)
 end
 cache_filldata!(K::PowerLawIntegral, inds) = _legendrepowerlaw_fill_data!(K, inds)
 

--- a/src/stieltjes.jl
+++ b/src/stieltjes.jl
@@ -141,7 +141,6 @@ function Base.getindex(A::PowerLawIntegral{T, PP}, I::CartesianIndex) where {T,P
     A.data[I]
 end
 function getindex(A::PowerLawIntegral{T,PP}, I::Vararg{Int,2}) where {T,PP<:AbstractQuasiMatrix}
-    # @boundscheck checkbounds(A, I...)
     resizedata!(A, Tuple([I...]))
     A.data[I...]
 end
@@ -155,9 +154,11 @@ function resizedata!(A::PowerLawIntegral, nm)
         A.data = similar(A.data, nm...)
         A.data[axes(olddata)...] = olddata
     end
-    inds = Array(maximum(νμ):maximum(nm))
-    cache_filldata!(A, inds)
-    A.datasize = nm
+    if maximum(nm) > maximum(νμ)
+        inds = Array(maximum(νμ):maximum(nm))
+        cache_filldata!(A, inds)
+        A.datasize = nm
+    end
     A
 end
 

--- a/test/test_normalized.jl
+++ b/test/test_normalized.jl
@@ -3,6 +3,8 @@ import ClassicalOrthogonalPolynomials: NormalizationConstant, NormalizedBasisLay
 import LazyArrays: CachedVector, PaddedLayout
 import ContinuumArrays: MappedWeightedBasisLayout
 
+
+
 @testset "Normalized" begin
     @testset "Legendre" begin
         P = Legendre()
@@ -10,7 +12,7 @@ import ContinuumArrays: MappedWeightedBasisLayout
 
         @testset "Basic" begin
             @test MemoryLayout(Q) isa NormalizedBasisLayout
-            @test @inferred(Q\Q) ≡ Eye(∞)
+            @test_broken @inferred(Q\Q) ≡ Eye(∞)
             @test Q == Q
             @test P ≠ Q
             @test Q ≠ P

--- a/test/test_normalized.jl
+++ b/test/test_normalized.jl
@@ -3,8 +3,6 @@ import ClassicalOrthogonalPolynomials: NormalizationConstant, NormalizedBasisLay
 import LazyArrays: CachedVector, PaddedLayout
 import ContinuumArrays: MappedWeightedBasisLayout
 
-
-
 @testset "Normalized" begin
     @testset "Legendre" begin
         P = Legendre()
@@ -12,7 +10,7 @@ import ContinuumArrays: MappedWeightedBasisLayout
 
         @testset "Basic" begin
             @test MemoryLayout(Q) isa NormalizedBasisLayout
-            @test_broken @inferred(Q\Q) ≡ Eye(∞)
+            @test Q\Q ≡ Eye(∞)
             @test Q == Q
             @test P ≠ Q
             @test Q ≠ P

--- a/test/test_stieltjes.jl
+++ b/test/test_stieltjes.jl
@@ -1,5 +1,5 @@
 using ClassicalOrthogonalPolynomials, ContinuumArrays, DomainSets, Test
-import ClassicalOrthogonalPolynomials: Hilbert, StieltjesPoint
+import ClassicalOrthogonalPolynomials: Hilbert, StieltjesPoint, PowerLawMatrix, PowKernelPoint, dot, *
 
 @testset "Stieltjes" begin
     T = Chebyshev()
@@ -67,4 +67,98 @@ end
     u =  wT * (2 *(T \ exp.(x)))
     @test u[0.1] ≈ exp(0.1)/sqrt(0.1-0.1^2)
     @test (L * u)[0.5] ≈ -7.471469928754152 # Mathematica
+end
+
+#################################################
+# ∫f(x)g(x)(t-x)^a dx evaluation where f and g in Legendre
+#################################################
+
+@testset "PowerLawMatrix methods" begin
+    P = Legendre()
+    x = axes(P,1)
+    a = 2*rand(1)[1]
+    t = 1.00023
+    A = PowerLawMatrix(a,t)
+    @test (P\(P*A*(P\exp.(x))))[1:20] ≈ (P\((t.-x).^a.*exp.(x)))[1:20]
+    f = P \ exp.(x)
+    @test (P*A*f)[0.2] ≈ (t-0.2)^a*exp(0.2)
+end
+
+@testset "dot() for PowerKernelPoint of Legendre" begin
+    @testset "PowKernelPoint basics" begin
+        # basis
+        P = Legendre()
+        x = axes(P,1)
+        # define set 1
+        a = 2*rand(1)[1]
+        t = 1.0000000001
+        K1 = ((t .- x)).^a
+        # define set 2
+        a = 2*rand(1)[1]
+        t = rand(1)[1]+1
+        K2 = ((t .- x)).^a
+        # run tests
+        @test K1 isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
+        @test K2 isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
+    end
+    @testset "PowKernelPoint dot evaluation finite" begin
+        # basis
+        P = Legendre()
+        x = axes(P,1)
+        # set 1, same length coefficient vectors
+        f = P[:,1:30] \ abs.(π*x.^7)
+        g = P[:,1:30] \ (cosh.(x.^3).*exp.(x.^(2)))
+        a = 1.9127
+        t = 1.211
+        K = ((t .- x)).^a
+        @test dot(f,K,g) ≈ 5.082145576355614 # Mathematica
+        # set 2, different length coefficient vectors
+        f = P[:,1:20] \ exp.(x.^2)
+        g = P[:,1:40] \ (sin.(x).*exp.(x.^(2)))
+        a = 1.23
+        t = 1.00001
+        K = ((t .- x)).^a
+        @test dot(f,K,g) ≈ -2.656108697646584 # Mathematica
+    end
+    @testset "PowKernelPoint dot evaluation infinite" begin
+        # basis
+        P = Legendre()
+        x = axes(P,1)
+        # set 1
+        f = P \ abs.(π*x.^7)
+        g = P \ (cosh.(x.^3).*exp.(x.^(2)))
+        a = 1.9127
+        t = 1.211
+        K = ((t .- x)).^a
+        @test dot(f,K,g) ≈ 5.082145576355614 # Mathematica
+        # set 2
+        f = P \ exp.(x.^2)
+        g = P \ (sin.(x).*exp.(x.^(2)))
+        a = 1.23
+        t = 1.00001
+        K = ((t .- x)).^a
+        @test dot(f,K,g) ≈ -2.656108697646584 # Mathematica
+    end
+end
+
+@testset "more explicit evaluation tests" begin
+    # basis
+    a = 2.9184
+    t = 1.000001
+    P = Legendre()
+    x = axes(P,1)
+        # operator
+    KP = (t .- x).^a
+    @test KP isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
+        # functions
+    f = P \ exp.(x)
+    g = P \ sin.(x)
+    const1(x) = 1
+    onevec = P \ const1.(x)
+        # dot() and * methods tests, explicit values via Mathematica
+    @test -2.062500116206712 ≈ dot(onevec,KP,g) == onevec'*KP*g
+    @test 2.266485452423447 ≈ dot(onevec,KP,f) == onevec'*KP*f
+    @test -0.954305839543464 ≈ g'*KP*f == dot(g,KP,f)
+    @test 1.544769699288028 ≈ f'*KP*f == dot(f,KP,f)
+    @test 1.420460011606107 ≈ g'*KP*g == dot(g,KP,g)
 end

--- a/test/test_stieltjes.jl
+++ b/test/test_stieltjes.jl
@@ -81,6 +81,19 @@ end
             @test (t.-x).^a isa PowKernelPoint
             @test (t.-x).^a*P isa typeof(P*PowerLawMatrix(P,a,t))
         end
+    # basis
+    P = Normalized(Legendre())
+    x = axes(P,1)
+    # some functions
+    f = P \ exp.(x.^2)
+    g = P \ (sin.(x).*exp.(x.^(2)))
+    # some parameters for (t-x)^a
+    a = BigFloat("1.23")
+    t = BigFloat("1.00001")
+    # define powerlaw multiplication
+    W = (t.-x).^a
+    # check if it can compute the integral correctly
+    @test g'*(P'*(W*P)*f) ≈ -2.656108697646584 # Mathematica
 end
 @testset "Equivalence to multiplication in integer case" begin
         P=Normalized(Legendre())
@@ -159,9 +172,9 @@ end
         const1(x) = 1
         onevec = P \ const1.(x)
         # dot() and * methods tests, explicit values via Mathematica
-        @test -2.062500116206712 ≈ dot(onevec,W,g) == onevec'*W*g
-        @test 2.266485452423447 ≈ dot(onevec,W,f) == onevec'*W*f
-        @test -0.954305839543464 ≈ g'*W*f == dot(g,W,f)
-        @test 1.544769699288028 ≈ f'*W*f == dot(f,W,f)
-        @test 1.420460011606107 ≈ g'*W*g == dot(g,W,g)
+        @test -2.062500116206712 ≈ dot(onevec,W,g)
+        @test 2.266485452423447 ≈ dot(onevec,W,f)
+        @test -0.954305839543464 ≈ dot(g,W,f)
+        @test 1.544769699288028 ≈ dot(f,W,f)
+        @test 1.420460011606107 ≈ dot(g,W,g)
 end

--- a/test/test_stieltjes.jl
+++ b/test/test_stieltjes.jl
@@ -158,7 +158,7 @@ end
         g = P \ cos.(x.^3)
         @test dot(f,W,g) ≈ -0.1249375144525209 # Mathematica
 end
-@testset "more explicit evaluation tests" begin
+@testset "More explicit evaluation tests" begin
         # basis
         a = 2.9184
         t = 1.000001
@@ -177,4 +177,27 @@ end
         @test -0.954305839543464 ≈ dot(g,W,f)
         @test 1.544769699288028 ≈ dot(f,W,f)
         @test 1.420460011606107 ≈ dot(g,W,g)
+end
+@testset "Tests for -1<a<0" begin
+    P = Normalized(Legendre())
+    x = axes(P,1)
+    a=-0.7
+    t=1.271
+    # operator
+    W = PowerLawMatrix(P,a,t)
+    WB = PowerLawMatrix(P,BigFloat("$a"),BigFloat("$t"))
+    # functions
+    f0 = P \ exp.(2 .*x.^2)
+    g0 = P \ sin.(x)
+    @test dot(f0,W,g0) ≈  dot(f0,WB,g0) ≈ 1.670106472636101 # Mathematica
+    f1 = P \ ((x.^2)./3 .+(x.^3)./3)
+    g1 = P \ (x.*exp.(x.^3))
+    @test dot(f1,W,g1) ≈ dot(f1,WB,g1) ≈ 0.5362428541997497 # Mathematica
+    a = -0.08488959029015586
+    t = 1.000001
+    W = PowerLawMatrix(P,a,t)
+    WB = PowerLawMatrix(P,BigFloat("$a"),BigFloat("$t"))
+    f2 = P \ ((x.^2)./3 .+ cosh.(x.^4).*(x.^3)./3)
+    g2 = P \ (x.*exp.(x.^3))
+    @test dot(f2,W,g2) ≈ dot(f2,WB,g2) ≈ 0.3841478354955073 # Mathematica
 end

--- a/test/test_stieltjes.jl
+++ b/test/test_stieltjes.jl
@@ -1,5 +1,5 @@
 using ClassicalOrthogonalPolynomials, ContinuumArrays, DomainSets, Test
-import ClassicalOrthogonalPolynomials: Hilbert, StieltjesPoint, PowerLawIntegral, PowKernelPoint, pointwisecoeffmatrixdense, *
+import ClassicalOrthogonalPolynomials: Hilbert, StieltjesPoint, PowerLawIntegral, PowKernelIntegralPoint, pointwisecoeffmatrixdense, *, dot
 
 @testset "Stieltjes" begin
     T = Chebyshev()
@@ -73,105 +73,95 @@ end
 # ∫f(x)g(x)(t-x)^a dx evaluation where f and g in Legendre
 #################################################
 
-# TODO: more tests would be nice, this is very basic
-@testset "Cached Legendre power law integral" begin
-    a = 2*rand(1)[1]
-    t = 1.0000000001
-    Acached = PowerLawIntegral(Legendre(),a,t)
-    @test size(Acached) == (∞,∞)
-    @test Acached[1:10,1:10] == pointwisecoeffmatrixdense(a,t,10)
+@testset "dot() for PowerKernelPoint of Legendre" begin
+    @testset "Cached Legendre power law integral" begin
+        a = 2*rand(1)[1]
+        t = 1.0000000001
+        Acached = PowerLawIntegral(Legendre(),a,t)
+        @test size(Acached) == (∞,∞)
+        @test Acached[1:20,1:20] == pointwisecoeffmatrixdense(a,t,20)
+    end
+    @testset "PowKernelPoint dot evaluation finite" begin
+        # basis
+        P = Legendre()
+        x = axes(P,1)
+        # set 1, same length coefficient vectors
+        f = P \ abs.(π*x.^7)
+        g = P \ (cosh.(x.^3).*exp.(x.^(2)))
+        f = f[1:30]
+        g = g[1:30]
+        a = 1.9127
+        t = 1.211
+        W = P' * ((t .- x).^a .* P)
+        @test W isa PowKernelIntegralPoint
+        @test dot(f,W,g) ≈ 5.082145576355614 # Mathematica
+        # set 2, different length coefficient vectors
+        f = P \ exp.(x.^2)
+        g = P \ (sin.(x).*exp.(x.^(2)))
+        f = f[1:20]
+        g = g[1:40]
+        a = 1.23
+        t = 1.00001
+        W = P' * ((t .- x).^a .* P)
+        @test W isa PowKernelIntegralPoint
+        @test dot(f,W,g) ≈ -2.656108697646584 # Mathematica
+    end
+    @testset "PowKernelPoint dot evaluation infinite" begin
+        # basis
+        P = Legendre()
+        x = axes(P,1)
+        # set 1
+        f = P \ abs.(π*x.^7)
+        g = P \ (cosh.(x.^3).*exp.(x.^(2)))
+        a = 1.9127
+        t = 1.211
+        W = P' * ((t .- x).^a .* P)
+        @test W isa PowKernelIntegralPoint
+        @test dot(f,W,g) ≈ 5.082145576355614 # Mathematica
+        # set 2
+        f = P \ exp.(x.^2)
+        g = P \ (sin.(x).*exp.(x.^(2)))
+        a = 1.23
+        t = 1.00001
+        W = P' * ((t .- x).^a .* P)
+        @test W isa PowKernelIntegralPoint
+        @test dot(f,W,g) ≈ -2.656108697646584 # Mathematica
+       # set 3
+        t = 1.2
+        a = 1.1
+        W = P' * ((t .- x).^a .* P)
+        f = P \ exp.(x)
+        g = P \ exp.(x.^2)
+        @test W isa PowKernelIntegralPoint
+        @test dot(f,W,g) ≈ 2.916955525390389 # Mathematica
+        # set 4
+        t = 1.001
+        a = 1.001
+        W = P' * ((t .- x).^a .* P)
+        f = P \ (sinh.(x).*exp.(x))
+        g = P \ cos.(x.^3)
+        @test W isa PowKernelIntegralPoint
+        @test dot(f,W,g) ≈ -0.1249375144525209 # Mathematica
+    end
+    @testset "more explicit evaluation tests" begin
+        # basis
+        a = 2.9184
+        t = 1.000001
+        P = Legendre()
+        x = axes(P,1)
+            # operator
+        W = P' * ((t .- x).^a .* P)
+        @test W isa PowKernelIntegralPoint
+            # functions
+        f = P \ exp.(x)
+        g = P \ sin.(x)
+        const1(x) = 1
+        onevec = P \ const1.(x)
+            # dot() and * methods tests, explicit values via Mathematica
+        @test -2.062500116206712 ≈ dot(onevec,W,g) == onevec'*W*g
+        @test 2.266485452423447 ≈ dot(onevec,W,f) == onevec'*W*f
+        @test -0.954305839543464 ≈ g'*W*f == dot(g,W,f)
+        @test 1.544769699288028 ≈ f'*W*f == dot(f,W,f)
+        @test 1.420460011606107 ≈ g'*W*g == dot(g,W,g)
+    end
 end
-
-# TODO: make these tests work again with new cached variant
-# @testset "PowerLawMatrix methods" begin
-#     P = Legendre()
-#     x = axes(P,1)
-#     a = 2*rand(1)[1]
-#     t = 1.00023
-#     A = PowerLawMatrix(a,t)
-#     @test (P\(P*A*(P\exp.(x))))[1:20] ≈ (P\((t.-x).^a.*exp.(x)))[1:20]
-#     f = P \ exp.(x)
-#     @test (P*A*f)[0.2] ≈ (t-0.2)^a*exp(0.2)
-# end
-# @testset "dot() for PowerKernelPoint of Legendre" begin
-#     @testset "PowKernelPoint basics" begin
-#         # basis
-#         P = Legendre()
-#         x = axes(P,1)
-#         # define set 1
-#         a = 2*rand(1)[1]
-#         t = 1.0000000001
-#         K1 = ((t .- x)).^a
-#         # define set 2
-#         a = 2*rand(1)[1]
-#         t = rand(1)[1]+1
-#         K2 = ((t .- x)).^a
-#         # run tests
-#         @test K1 isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
-#         @test K2 isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
-#     end
-#     @testset "PowKernelPoint dot evaluation finite" begin
-#         # basis
-#         P = Legendre()
-#         x = axes(P,1)
-#         # set 1, same length coefficient vectors
-#         f = P \ abs.(π*x.^7)
-#         g = P \ (cosh.(x.^3).*exp.(x.^(2)))
-#         f = f[1:30]
-#         g = f[1:30]
-#         a = 1.9127
-#         t = 1.211
-#         K = ((t .- x)).^a
-#         @test dot(f,K,g) ≈ 5.082145576355614 # Mathematica
-#         # set 2, different length coefficient vectors
-#         f = P \ exp.(x.^2)
-#         g = P \ (sin.(x).*exp.(x.^(2)))
-#         f = f[1:20]
-#         g = f[1:40]
-#         a = 1.23
-#         t = 1.00001
-#         K = ((t .- x)).^a
-#         @test dot(f,K,g) ≈ -2.656108697646584 # Mathematica
-#     end
-#     @testset "PowKernelPoint dot evaluation infinite" begin
-#         # basis
-#         P = Legendre()
-#         x = axes(P,1)
-#         # set 1
-#         f = P \ abs.(π*x.^7)
-#         g = P \ (cosh.(x.^3).*exp.(x.^(2)))
-#         a = 1.9127
-#         t = 1.211
-#         K = ((t .- x)).^a
-#         @test dot(f,K,g) ≈ 5.082145576355614 # Mathematica
-#         # set 2
-#         f = P \ exp.(x.^2)
-#         g = P \ (sin.(x).*exp.(x.^(2)))
-#         a = 1.23
-#         t = 1.00001
-#         K = ((t .- x)).^a
-#         @test dot(f,K,g) ≈ -2.656108697646584 # Mathematica
-#     end
-# end
-
-# @testset "more explicit evaluation tests" begin
-#     # basis
-#     a = 2.9184
-#     t = 1.000001
-#     P = Legendre()
-#     x = axes(P,1)
-#         # operator
-#     KP = (t .- x).^a
-#     @test KP isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
-#         # functions
-#     f = P \ exp.(x)
-#     g = P \ sin.(x)
-#     const1(x) = 1
-#     onevec = P \ const1.(x)
-#         # dot() and * methods tests, explicit values via Mathematica
-#     @test -2.062500116206712 ≈ dot(onevec,KP,g) == onevec'*KP*g
-#     @test 2.266485452423447 ≈ dot(onevec,KP,f) == onevec'*KP*f
-#     @test -0.954305839543464 ≈ g'*KP*f == dot(g,KP,f)
-#     @test 1.544769699288028 ≈ f'*KP*f == dot(f,KP,f)
-#     @test 1.420460011606107 ≈ g'*KP*g == dot(g,KP,g)
-# end

--- a/test/test_stieltjes.jl
+++ b/test/test_stieltjes.jl
@@ -1,5 +1,5 @@
 using ClassicalOrthogonalPolynomials, ContinuumArrays, DomainSets, Test
-import ClassicalOrthogonalPolynomials: Hilbert, StieltjesPoint, PowerLawIntegral, PowKernelPoint, pointwisecoeffmatrixdensedot, *
+import ClassicalOrthogonalPolynomials: Hilbert, StieltjesPoint, PowerLawIntegral, PowKernelPoint, pointwisecoeffmatrixdense, *
 
 @testset "Stieltjes" begin
     T = Chebyshev()
@@ -79,7 +79,7 @@ end
     t = 1.0000000001
     Acached = PowerLawIntegral(Legendre(),a,t)
     @test size(Acached) == (∞,∞)
-    @test Acached[1:10,1:10] == ClassicalOrthogonalPolynomials.pointwisecoeffmatrixdense(a,t,10)
+    @test Acached[1:10,1:10] == pointwisecoeffmatrixdense(a,t,10)
 end
 
 # TODO: make these tests work again with new cached variant

--- a/test/test_stieltjes.jl
+++ b/test/test_stieltjes.jl
@@ -1,5 +1,5 @@
 using ClassicalOrthogonalPolynomials, ContinuumArrays, DomainSets, Test
-import ClassicalOrthogonalPolynomials: Hilbert, StieltjesPoint, PowerLawMatrix, PowKernelPoint, dot, *
+import ClassicalOrthogonalPolynomials: Hilbert, StieltjesPoint, PowerLawIntegral, PowKernelPoint, pointwisecoeffmatrixdensedot, *
 
 @testset "Stieltjes" begin
     T = Chebyshev()
@@ -73,92 +73,105 @@ end
 # ∫f(x)g(x)(t-x)^a dx evaluation where f and g in Legendre
 #################################################
 
-@testset "PowerLawMatrix methods" begin
-    P = Legendre()
-    x = axes(P,1)
+# TODO: more tests would be nice, this is very basic
+@testset "Cached Legendre power law integral" begin
     a = 2*rand(1)[1]
-    t = 1.00023
-    A = PowerLawMatrix(a,t)
-    @test (P\(P*A*(P\exp.(x))))[1:20] ≈ (P\((t.-x).^a.*exp.(x)))[1:20]
-    f = P \ exp.(x)
-    @test (P*A*f)[0.2] ≈ (t-0.2)^a*exp(0.2)
+    t = 1.0000000001
+    Acached = PowerLawIntegral(Legendre(),a,t)
+    @test size(Acached) == (∞,∞)
+    @test Acached[1:10,1:10] == ClassicalOrthogonalPolynomials.pointwisecoeffmatrixdense(a,t,10)
 end
 
-@testset "dot() for PowerKernelPoint of Legendre" begin
-    @testset "PowKernelPoint basics" begin
-        # basis
-        P = Legendre()
-        x = axes(P,1)
-        # define set 1
-        a = 2*rand(1)[1]
-        t = 1.0000000001
-        K1 = ((t .- x)).^a
-        # define set 2
-        a = 2*rand(1)[1]
-        t = rand(1)[1]+1
-        K2 = ((t .- x)).^a
-        # run tests
-        @test K1 isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
-        @test K2 isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
-    end
-    @testset "PowKernelPoint dot evaluation finite" begin
-        # basis
-        P = Legendre()
-        x = axes(P,1)
-        # set 1, same length coefficient vectors
-        f = P[:,1:30] \ abs.(π*x.^7)
-        g = P[:,1:30] \ (cosh.(x.^3).*exp.(x.^(2)))
-        a = 1.9127
-        t = 1.211
-        K = ((t .- x)).^a
-        @test dot(f,K,g) ≈ 5.082145576355614 # Mathematica
-        # set 2, different length coefficient vectors
-        f = P[:,1:20] \ exp.(x.^2)
-        g = P[:,1:40] \ (sin.(x).*exp.(x.^(2)))
-        a = 1.23
-        t = 1.00001
-        K = ((t .- x)).^a
-        @test dot(f,K,g) ≈ -2.656108697646584 # Mathematica
-    end
-    @testset "PowKernelPoint dot evaluation infinite" begin
-        # basis
-        P = Legendre()
-        x = axes(P,1)
-        # set 1
-        f = P \ abs.(π*x.^7)
-        g = P \ (cosh.(x.^3).*exp.(x.^(2)))
-        a = 1.9127
-        t = 1.211
-        K = ((t .- x)).^a
-        @test dot(f,K,g) ≈ 5.082145576355614 # Mathematica
-        # set 2
-        f = P \ exp.(x.^2)
-        g = P \ (sin.(x).*exp.(x.^(2)))
-        a = 1.23
-        t = 1.00001
-        K = ((t .- x)).^a
-        @test dot(f,K,g) ≈ -2.656108697646584 # Mathematica
-    end
-end
+# TODO: make these tests work again with new cached variant
+# @testset "PowerLawMatrix methods" begin
+#     P = Legendre()
+#     x = axes(P,1)
+#     a = 2*rand(1)[1]
+#     t = 1.00023
+#     A = PowerLawMatrix(a,t)
+#     @test (P\(P*A*(P\exp.(x))))[1:20] ≈ (P\((t.-x).^a.*exp.(x)))[1:20]
+#     f = P \ exp.(x)
+#     @test (P*A*f)[0.2] ≈ (t-0.2)^a*exp(0.2)
+# end
+# @testset "dot() for PowerKernelPoint of Legendre" begin
+#     @testset "PowKernelPoint basics" begin
+#         # basis
+#         P = Legendre()
+#         x = axes(P,1)
+#         # define set 1
+#         a = 2*rand(1)[1]
+#         t = 1.0000000001
+#         K1 = ((t .- x)).^a
+#         # define set 2
+#         a = 2*rand(1)[1]
+#         t = rand(1)[1]+1
+#         K2 = ((t .- x)).^a
+#         # run tests
+#         @test K1 isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
+#         @test K2 isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
+#     end
+#     @testset "PowKernelPoint dot evaluation finite" begin
+#         # basis
+#         P = Legendre()
+#         x = axes(P,1)
+#         # set 1, same length coefficient vectors
+#         f = P \ abs.(π*x.^7)
+#         g = P \ (cosh.(x.^3).*exp.(x.^(2)))
+#         f = f[1:30]
+#         g = f[1:30]
+#         a = 1.9127
+#         t = 1.211
+#         K = ((t .- x)).^a
+#         @test dot(f,K,g) ≈ 5.082145576355614 # Mathematica
+#         # set 2, different length coefficient vectors
+#         f = P \ exp.(x.^2)
+#         g = P \ (sin.(x).*exp.(x.^(2)))
+#         f = f[1:20]
+#         g = f[1:40]
+#         a = 1.23
+#         t = 1.00001
+#         K = ((t .- x)).^a
+#         @test dot(f,K,g) ≈ -2.656108697646584 # Mathematica
+#     end
+#     @testset "PowKernelPoint dot evaluation infinite" begin
+#         # basis
+#         P = Legendre()
+#         x = axes(P,1)
+#         # set 1
+#         f = P \ abs.(π*x.^7)
+#         g = P \ (cosh.(x.^3).*exp.(x.^(2)))
+#         a = 1.9127
+#         t = 1.211
+#         K = ((t .- x)).^a
+#         @test dot(f,K,g) ≈ 5.082145576355614 # Mathematica
+#         # set 2
+#         f = P \ exp.(x.^2)
+#         g = P \ (sin.(x).*exp.(x.^(2)))
+#         a = 1.23
+#         t = 1.00001
+#         K = ((t .- x)).^a
+#         @test dot(f,K,g) ≈ -2.656108697646584 # Mathematica
+#     end
+# end
 
-@testset "more explicit evaluation tests" begin
-    # basis
-    a = 2.9184
-    t = 1.000001
-    P = Legendre()
-    x = axes(P,1)
-        # operator
-    KP = (t .- x).^a
-    @test KP isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
-        # functions
-    f = P \ exp.(x)
-    g = P \ sin.(x)
-    const1(x) = 1
-    onevec = P \ const1.(x)
-        # dot() and * methods tests, explicit values via Mathematica
-    @test -2.062500116206712 ≈ dot(onevec,KP,g) == onevec'*KP*g
-    @test 2.266485452423447 ≈ dot(onevec,KP,f) == onevec'*KP*f
-    @test -0.954305839543464 ≈ g'*KP*f == dot(g,KP,f)
-    @test 1.544769699288028 ≈ f'*KP*f == dot(f,KP,f)
-    @test 1.420460011606107 ≈ g'*KP*g == dot(g,KP,g)
-end
+# @testset "more explicit evaluation tests" begin
+#     # basis
+#     a = 2.9184
+#     t = 1.000001
+#     P = Legendre()
+#     x = axes(P,1)
+#         # operator
+#     KP = (t .- x).^a
+#     @test KP isa PowKernelPoint{Float64,Float64,ChebyshevInterval{Float64}}
+#         # functions
+#     f = P \ exp.(x)
+#     g = P \ sin.(x)
+#     const1(x) = 1
+#     onevec = P \ const1.(x)
+#         # dot() and * methods tests, explicit values via Mathematica
+#     @test -2.062500116206712 ≈ dot(onevec,KP,g) == onevec'*KP*g
+#     @test 2.266485452423447 ≈ dot(onevec,KP,f) == onevec'*KP*f
+#     @test -0.954305839543464 ≈ g'*KP*f == dot(g,KP,f)
+#     @test 1.544769699288028 ≈ f'*KP*f == dot(f,KP,f)
+#     @test 1.420460011606107 ≈ g'*KP*g == dot(g,KP,g)
+# end


### PR DESCRIPTION
The aim is to allow for fast and importantly t->1 compatible computation of \int_{-1}^1 (t-x)^a f(x) g(x) dx where f and g are given in Legendre polynomial coefficients.