### PR TITLE
BigFloat accurate conversion operators

### DIFF
--- a/src/ClassicalOrthogonalPolynomials.jl
+++ b/src/ClassicalOrthogonalPolynomials.jl
@@ -5,7 +5,7 @@ using IntervalSets: UnitRange
 using ContinuumArrays, QuasiArrays, LazyArrays, FillArrays, BandedMatrices, BlockArrays,
     IntervalSets, DomainSets, ArrayLayouts, SpecialFunctions,
     InfiniteLinearAlgebra, InfiniteArrays, LinearAlgebra, FastGaussQuadrature, FastTransforms, FFTW,
-    LazyBandedMatrices, HypergeometricFunctions
+    LazyBandedMatrices, HypergeometricFunctions, GenericLinearAlgebra
 
 import Base: @_inline_meta, axes, getindex, unsafe_getindex, convert, prod, *, /, \, +, -,
                 IndexStyle, IndexLinear, ==, OneTo, tail, similar, copyto!, copy, setindex,
@@ -110,7 +110,7 @@ _equals(::WeightedOPLayout, ::WeightedOPLayout, wP, wQ) = unweighted(wP) == unwe
 _equals(::WeightedOPLayout, ::WeightedBasisLayout, wP, wQ) = unweighted(wP) == unweighted(wQ) && weight(wP) == weight(wQ)
 _equals(::WeightedBasisLayout, ::WeightedOPLayout, wP, wQ) = unweighted(wP) == unweighted(wQ) && weight(wP) == weight(wQ)
 _equals(::WeightedBasisLayout{<:AbstractOPLayout}, ::WeightedBasisLayout{<:AbstractOPLayout}, wP, wQ) = unweighted(wP) == unweighted(wQ) && weight(wP) == weight(wQ)
-    
+
 
 copy(L::Ldiv{MappedOPLayout,Lay}) where Lay<:MappedBasisLayouts = copy(Ldiv{MappedBasisLayout,Lay}(L.A,L.B))
 
@@ -259,7 +259,11 @@ grid(P::SubQuasiArray{<:Any,2,<:OrthogonalPolynomial,<:Tuple{Inclusion,Any}}) =
     eigvals(symtridiagonalize(jacobimatrix(P)))
 
 function golubwelsch(X)
-    D, V = eigen(symtridiagonalize(X))  # Eigenvalue decomposition
+    if typeof(X[1,1]) == BigFloat
+        D, V = eigen(Hermitian(symtridiagonalize(X)))
+    else
+        D, V = eigen(symtridiagonalize(X))  # Eigenvalue decomposition
+    end
     D, V[1,:].^2
 end
 

--- a/src/ClassicalOrthogonalPolynomials.jl
+++ b/src/ClassicalOrthogonalPolynomials.jl
@@ -5,7 +5,7 @@ using IntervalSets: UnitRange
 using ContinuumArrays, QuasiArrays, LazyArrays, FillArrays, BandedMatrices, BlockArrays,
     IntervalSets, DomainSets, ArrayLayouts, SpecialFunctions,
     InfiniteLinearAlgebra, InfiniteArrays, LinearAlgebra, FastGaussQuadrature, FastTransforms, FFTW,
-    LazyBandedMatrices, HypergeometricFunctions, GenericLinearAlgebra
+    LazyBandedMatrices, HypergeometricFunctions
 
 import Base: @_inline_meta, axes, getindex, unsafe_getindex, convert, prod, *, /, \, +, -,
                 IndexStyle, IndexLinear, ==, OneTo, tail, similar, copyto!, copy, setindex,
@@ -259,11 +259,7 @@ grid(P::SubQuasiArray{<:Any,2,<:OrthogonalPolynomial,<:Tuple{Inclusion,Any}}) =
     eigvals(symtridiagonalize(jacobimatrix(P)))
 
 function golubwelsch(X)
-    if typeof(X[1,1]) == BigFloat
-        D, V = eigen(Hermitian(symtridiagonalize(X)))
-    else
-        D, V = eigen(symtridiagonalize(X))  # Eigenvalue decomposition
-    end
+    D, V = eigen(symtridiagonalize(X))  # Eigenvalue decomposition
     D, V[1,:].^2
 end
 

--- a/src/classical/chebyshev.jl
+++ b/src/classical/chebyshev.jl
@@ -118,7 +118,7 @@ factorize(L::SubQuasiArray{T,2,<:ChebyshevU,<:Tuple{<:Inclusion,<:OneTo}}) where
 # Jacobi Matrix
 ########
 
-jacobimatrix(C::ChebyshevT{T}) where T = 
+jacobimatrix(C::ChebyshevT{T}) where T =
     Tridiagonal(Vcat(one(T), Fill(one(T)/2,∞)), Zeros{T}(∞), Fill(one(T)/2,∞))
 
 jacobimatrix(C::ChebyshevU{T}) where T =
@@ -126,7 +126,7 @@ jacobimatrix(C::ChebyshevU{T}) where T =
 
 
 
-# These return vectors A[k], B[k], C[k] are from DLMF. 
+# These return vectors A[k], B[k], C[k] are from DLMF.
 recurrencecoefficients(C::ChebyshevT) = (Vcat(1, Fill(2,∞)), Zeros{Int}(∞), Ones{Int}(∞))
 recurrencecoefficients(C::ChebyshevU) = (Fill(2,∞), Zeros{Int}(∞), Ones{Int}(∞))
 
@@ -226,7 +226,7 @@ function \(A::ChebyshevT, B::Legendre)
             (iseven(k) == iseven(j) && j ≥ k) || return zero(T)
             k == 1 && return Λ(convert(T,j-1)/2)^2/π
             2/π * Λ(convert(T,j-k)/2) * Λ(convert(T,k+j-2)/2)
-        end, 1:∞, (1:∞)'))
+        end, convert(AbstractVector{T},1:∞), convert(AbstractVector{T},1:∞)'))
 end
 
 \(A::AbstractJacobi, B::Chebyshev) = ApplyArray(inv,B \ A)


### PR DESCRIPTION
I added the suggested fix in #88 but still don't get BigFloat accuracy.

I guess this is not related to the issue, but I think `eigen` only works for `Float64` https://github.com/JuliaApproximation/ClassicalOrthogonalPolynomials.jl/blob/459bdc674f52da080ec1d75236ccc1b6b3ebb520/src/ClassicalOrthogonalPolynomials.jl#L262

I can check if using GenericLinearAlgebra.jl and 
```julia
eigen(Hermitian(symtridiagonalize(X)))
```
would work for BigFloats. Any comments on this?