### PR TITLE
Replace ∞ with ℵ₀ in Lanczos sizes

### DIFF
--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -68,7 +68,7 @@ struct LanczosConversion{T} <: LayoutMatrix{T}
     data::LanczosData{T}
 end
 
-size(::LanczosConversion) = (∞,∞)
+size(::LanczosConversion) = (ℵ₀,ℵ₀)
 copy(R::LanczosConversion) = R
 
 Base.permutedims(R::LanczosConversion{<:Number}) = transpose(R)
@@ -128,7 +128,7 @@ struct LanczosJacobiBand{T} <: LazyVector{T}
     diag::Symbol
 end
 
-size(P::LanczosJacobiBand) = (∞,)
+size(P::LanczosJacobiBand) = (ℵ₀,)
 resizedata!(A::LanczosJacobiBand, n) = resizedata!(A.data, n)
 
 

--- a/test/test_lanczos.jl
+++ b/test/test_lanczos.jl
@@ -6,7 +6,13 @@ import ClassicalOrthogonalPolynomials: recurrencecoefficients, PaddedLayout, ort
         P = Legendre();
         w = P * [1; zeros(∞)];
         Q = LanczosPolynomial(w);
+        X = jacobimatrix(Q);
         @test Q.data.W[1:10,1:10] isa BandedMatrix
+        @test size(X) === (ℵ₀,ℵ₀) # make sure size uses ℵ₀ instead of ∞ 
+        # test taking integer powers of jacobi matrix
+        @test (X*X)[1:100,1:100] ≈ (X^2)[1:100,1:100]
+        @test (X*X*X)[1:100,1:100] ≈ (X^3)[1:100,1:100]
+        @test (X*X*X*X)[1:100,1:100] ≈ (X^4)[1:100,1:100]
 
         Q̃ = Normalized(P);
         A,B,C = recurrencecoefficients(Q);
@@ -177,6 +183,7 @@ import ClassicalOrthogonalPolynomials: recurrencecoefficients, PaddedLayout, ort
             U = LanczosPolynomial(y, P₊)
             @test P₊ ≠ U
             R = P₊ \ U
+            @test size(R) === (ℵ₀,ℵ₀)
             @test U[0.1,5] ≈ (P₊ * R * [zeros(4); 1; zeros(∞)])[0.1]
         end
     end


### PR DESCRIPTION
Fix https://github.com/JuliaApproximation/ClassicalOrthogonalPolynomials.jl/issues/121