### PR TITLE
Implement Q-based qrjacobimatrix() in O(n)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
-          - '1'
           - '^1.9.0-0'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -43,7 +43,7 @@ LazyArrays = "1.0.1"
 LazyBandedMatrices = "0.8.5"
 QuasiArrays = "0.9.6"
 SpecialFunctions = "1.0, 2"
-julia = "1.7"
+julia = "1.9"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClassicalOrthogonalPolynomials"
 uuid = "b30e2e7b-c4ee-47da-9d5f-2c5c27239acd"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.8.1"
+version = "0.9.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/ClassicalOrthogonalPolynomials.jl
+++ b/src/ClassicalOrthogonalPolynomials.jl
@@ -21,7 +21,7 @@ import LazyArrays: MemoryLayout, Applied, ApplyStyle, flatten, _flatten, adjoint
 import ArrayLayouts: MatMulVecAdd, materialize!, _fill_lmul!, sublayout, sub_materialize, lmul!, ldiv!, ldiv, transposelayout, triangulardata,
                         subdiagonaldata, diagonaldata, supdiagonaldata, mul, rowsupport, colsupport
 import LazyBandedMatrices: SymTridiagonal, Bidiagonal, Tridiagonal, unitblocks, BlockRange1, AbstractLazyBandedLayout
-import LinearAlgebra: pinv, factorize, qr, adjoint, transpose, dot, mul!, reflectorApply!
+import LinearAlgebra: pinv, factorize, qr, adjoint, transpose, dot, mul!
 import BandedMatrices: AbstractBandedLayout, AbstractBandedMatrix, _BandedMatrix, bandeddata
 import FillArrays: AbstractFill, getindex_value, SquareEye
 import DomainSets: components

--- a/src/ClassicalOrthogonalPolynomials.jl
+++ b/src/ClassicalOrthogonalPolynomials.jl
@@ -21,7 +21,7 @@ import LazyArrays: MemoryLayout, Applied, ApplyStyle, flatten, _flatten, adjoint
 import ArrayLayouts: MatMulVecAdd, materialize!, _fill_lmul!, sublayout, sub_materialize, lmul!, ldiv!, ldiv, transposelayout, triangulardata,
                         subdiagonaldata, diagonaldata, supdiagonaldata, mul, rowsupport, colsupport
 import LazyBandedMatrices: SymTridiagonal, Bidiagonal, Tridiagonal, unitblocks, BlockRange1, AbstractLazyBandedLayout
-import LinearAlgebra: pinv, factorize, qr, adjoint, transpose, dot, mul!
+import LinearAlgebra: pinv, factorize, qr, adjoint, transpose, dot, mul!, reflectorApply!
 import BandedMatrices: AbstractBandedLayout, AbstractBandedMatrix, _BandedMatrix, bandeddata
 import FillArrays: AbstractFill, getindex_value, SquareEye
 import DomainSets: components

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -150,12 +150,13 @@ function QRJacobiBand{:dv,:Q}(F, P::OrthogonalPolynomial{T}) where T
         # fill first entry (special case)
     M = X[1:b,1:b]
     getindex(F.factors,b,b) # pre-fill cached array
-    v = I + tril(F.factors[1:b,1:b],-1)
-    H = I - F.τ[1]*v[:,1]*v[:,1]'
+    v = [one(T);F.factors[1:b,1][2:end]]
+    H = I - F.τ[1]*v*v'
     M = H*M*H
     dv[1] = M[1,1]
         # fill second entry
-    H = I - F.τ[2]*v[:,2]*v[:,2]'
+    v = [zero(T);one(T);F.factors[1:b,2][3:end]]
+    H = I - F.τ[2]*v*v'
     K = H*M*H
     M = Matrix(X[2:b+1,2:b+1])
     M[1:end-1,1:end-1] = K[2:end,2:end]
@@ -170,11 +171,12 @@ function QRJacobiBand{:ev,:Q}(F, P::OrthogonalPolynomial{T}) where T
         # first step does not produce entries for the off-diagonal band (special case)
     M = X[1:b,1:b]
     getindex(F.factors,b,b) # pre-fill cached array
-    v = (I + tril(F.factors[1:b,1:b],-1))
-    H = I - F.τ[1]*v[:,1]*v[:,1]'
+    v = [one(T);F.factors[1:b,1][2:end]]
+    H = I - F.τ[1]*v*v'
     M = H*M*H
         # fill first off-diagonal entry
-    H = I - F.τ[2]*v[:,2]*v[:,2]'
+    v = [zero(T);one(T);F.factors[1:b,2][3:end]]
+    H = I - F.τ[2]*v*v'
     K = H*M*H
     dv[1] = K[1,2]*sign(F.R[1,1]*F.R[2,2]) # includes possible correction for sign (only needed in off-diagonal case), since the QR decomposition does not guarantee positive diagonal on R
     M = Matrix(X[2:b+1,2:b+1])
@@ -226,7 +228,7 @@ function cache_filldata!(J::QRJacobiBand{:dv,:Q,T}, inds::UnitRange{Int}) where 
     F = J.U.factors
     dv = J.data
     @inbounds for n in jj
-        v = (I + tril(F[n-1:n+b,n-1:n+b],-1))[:,2]
+        v = [zero(T);one(T);F[n-1:n+b,n][3:end]]
         H = I-τ[n]*v*v'
         K = H*M*H
         M = Matrix(X[n:n+b+1,n:n+b+1])
@@ -247,7 +249,7 @@ function cache_filldata!(J::QRJacobiBand{:ev,:Q,T}, inds::UnitRange{Int}) where 
     M, τ, F, dv = J.UX, J.U.τ, J.U.factors, J.data
     D = sign.(view(J.U.R,band(0)).*view(J.U.R,band(0))[2:end])
     @inbounds for n in jj
-        v = (I + tril(F[n:n+b+2,n:n+b+2],-1))[:,2]
+        v = [zero(T);one(T);F[n:n+b+2,n+1][3:end]]
         H = I - τ[n+1]*v*v'
         K = H*M*H
         dv[n] = K[1,2]

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -243,7 +243,7 @@ function cache_filldata!(J::QRJacobiBand{:ev,:Q,T}, inds::UnitRange{Int}) where 
     b = bandwidths(J.U.factors)[2]÷2
     # pre-fill cached arrays to avoid excessive cost from expansion in loop
     X = jacobimatrix(J.P)[1:m+b+2,1:m+b+2]
-    getindex(J.U.factors,m+b,m+b)
+    resizedata!(J.U.factors,m+b,m+b)
     getindex(J.U.R,m,m)
     getindex(J.U.τ,m)
     M, τ, F, dv = J.UX, J.U.τ, J.U.factors, J.data

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -244,7 +244,7 @@ function cache_filldata!(J::QRJacobiBand{:ev,:Q,T}, inds::UnitRange{Int}) where 
     # pre-fill cached arrays to avoid excessive cost from expansion in loop
     X = jacobimatrix(J.P)[1:m+b+2,1:m+b+2]
     resizedata!(J.U.factors,m+b,m+b)
-    getindex(J.U.R,m,m)
+    resizedata!(J.U.R,m,m)
     getindex(J.U.τ,m)
     M, τ, F, dv = J.UX, J.U.τ, J.U.factors, J.data
     D = sign.(view(J.U.R,band(0)).*view(J.U.R,band(0))[2:end])

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -145,11 +145,11 @@ mutable struct QRJacobiData{method,T} <: AbstractMatrix{T}
 end
 
 # computes H*M*H in-place, overwriting K
-function doublehouseholderapply!(M, τ, v, w)
-    mul!(w, M, v)  # M is symmetric
-    M .= M .- τ .* v .* w'
-    mul!(w, M, v)
-    M .= M .- τ .* w .* v'
+function doublehouseholderapply!(M::AbstractMatrix{T}, τ::T, v, w) where T
+    mul!(w, M, [zero(T);one(T);v])  # M is symmetric
+    M .= M .- τ .* [zero(T);one(T);v] .* w'
+    mul!(w, M, [zero(T);one(T);v])
+    M .= M .- τ .* w .* [zero(T);one(T);v]'
 end
 
 # Computes the initial data for the Jacobi operator bands
@@ -163,10 +163,15 @@ function QRJacobiData{:Q,T}(F, P) where T
     M = Matrix(X[1:b,1:b])
     resizedata!(F.factors,b,b)
     w = Vector{T}(undef, b)
-    doublehouseholderapply!(M,F.τ[1],[one(T);F.factors[2:b,1]],w)
+    # special case for first entry double Householder product
+    v = [one(T);view(F.factors,2:b,1)]
+    mul!(w, M, v)  # M is symmetric
+    M .= M .- F.τ[1] .* v .* w'
+    mul!(w, M, v)
+    M .= M .- F.τ[1] .* w .* v'
     dv[1] = M[1,1]
         # fill second entry
-    doublehouseholderapply!(M,F.τ[2],[zero(T);one(T);F.factors[3:b,2]],w)
+    doublehouseholderapply!(M,F.τ[2],view(F.factors,3:b,2),w)
     ev[1] = M[1,2]*sign(F.R[1,1]*F.R[2,2]) # includes possible correction for sign (only needed in off-diagonal case), since the QR decomposition does not guarantee positive diagonal on R
     K = Matrix(X[2:b+1,2:b+1])
     K[1:end-1,1:end-1] .= view(M,2:b,2:b)
@@ -221,13 +226,12 @@ function _fillqrbanddata!(J::QRJacobiData{:Q,T}, inds::UnitRange{Int}) where T
     M = Matrix{T}(undef,b+3,b+3)
     @inbounds for n in jj
         dv[n] = K[1,1] # no sign correction needed on diagonal entry due to cancellation
-        doublehouseholderapply!(K,τ[n+1],[zero(T);one(T);F[n+2:n+b+2,n+1]],w)
+        doublehouseholderapply!(K,τ[n+1],view(F,n+2:n+b+2,n+1),w)
         ev[n] = K[1,2]*D[n] # contains sign correction from QR not forcing positive diagonals
         M .= view(X,n+1:n+b+3,n+1:n+b+3)
         M[1:end-1,1:end-1] .= view(K,2:b+3,2:b+3)
         K .= M
     end
-    J.UX = M
 end
 
 function _fillqrbanddata!(J::QRJacobiData{:R,T}, inds::UnitRange{Int}) where T

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -144,7 +144,7 @@ mutable struct QRJacobiData{method,T} <: AbstractMatrix{T}
     datasize::Int         # size of so-far computed block 
 end
 
-# computes H*M*H in-place, overwriting K
+# computes H*M*H in-place, overwriting M
 function doublehouseholderapply!(M::AbstractMatrix{T}, τ::T, v, w) where T
     k = [zero(T);one(T);v]
     mul!(w, M, k)  # M is symmetric

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -170,7 +170,7 @@ function QRJacobiBand{:ev,:Q}(F, P::OrthogonalPolynomial{T}) where T
     dv = zeros(T,1)
         # first step does not produce entries for the off-diagonal band (special case)
     M = X[1:b,1:b]
-    getindex(F.factors,b,b) # pre-fill cached array
+resizedata!(F.factors,b,b)
     v = [one(T);F.factors[1:b,1][2:end]]
     H = I - F.τ[1]*v*v'
     M = H*M*H

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -206,7 +206,7 @@ function QRJacobiBand{:ev,:R}(F, P::OrthogonalPolynomial{T}) where T
     UX = ApplyArray(*,U,X)
     ev = zeros(T,2) # compute a length 2 vector on first go
     ev[1] = -UX[1,1]*U[1,2]/(U[1,1]*U[2,2])+UX[1,2]/U[2,2] # this is dot(view(UX,1,1:2), U[1:2,1:2] \ [zero(T); one(T)])
-    ev[2] = UX[2,1]*(-U[1,3]/U[1,1])+U[1,2]*U[2,3]/(U[1,1]*U[2,2])/U[3,3]-UX[2,2]*U[2,3]/(U[2,2]*U[3,3])+UX[2,3]/U[3,3] # this is dot(view(UX,2,1:3), U[1:3,1:3] \ [zeros(T,2); one(T)])
+    ev[2] = UX[2,1]/U[3,3]*(-U[1,3]/U[1,1]+U[1,2]*U[2,3]/(U[1,1]*U[2,2]))+UX[2,2]/U[3,3]*(-U[2,3]/U[2,2])+UX[2,3]/U[3,3] # this is dot(view(UX,2,1:3), U[1:3,1:3] \ [zeros(T,2); one(T)])
     return QRJacobiBand{:ev,:R,T}(ev, U, UX, P, 2)
 end
 

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -195,7 +195,7 @@ function QRJacobiBand{:dv,:R}(F, P::OrthogonalPolynomial{T}) where T
     UX = ApplyArray(*,U,X)
     dv = zeros(T,2) # compute a length 2 vector on first go
     dv[1] = UX[1,1]/U[1,1] # this is dot(view(UX,1,1), U[1,1] \ [one(T)])
-    dv[2] = dot(view(UX,2,1:2), [-U[1,2]/U[1,1],one(T)]./U[2,2]) # this is dot(view(UX,2,1:2), U[1:2,1:2] \ [zero(T); one(T)])
+    dv[2] = -U[1,2]*UX[2,1]/(U[1,1]*U[2,2])+UX[2,2]/U[2,2] # this is dot(view(UX,2,1:2), U[1:2,1:2] \ [zero(T); one(T)])
     return QRJacobiBand{:dv,:R,T}(dv, U, UX, P, 2)
 end
 function QRJacobiBand{:ev,:R}(F, P::OrthogonalPolynomial{T}) where T
@@ -204,8 +204,8 @@ function QRJacobiBand{:ev,:R}(F, P::OrthogonalPolynomial{T}) where T
     X = jacobimatrix(P)
     UX = ApplyArray(*,U,X)
     ev = zeros(T,2) # compute a length 2 vector on first go
-    ev[1] = dot(view(UX,1,1:2), [-U[1,2]/U[1,1],one(T)]./U[2,2]) # this is dot(view(UX,1,1:2), U[1:2,1:2] \ [zero(T); one(T)])
-    ev[2] = dot(view(UX,2,1:3), [(-U[1,3]/U[1,1])+U[1,2]*U[2,3]/(U[1,1]*U[2,2]),-U[2,3]/U[2,2],one(T)]./U[3,3]) # this is dot(view(UX,2,1:3), U[1:3,1:3] \ [zeros(T,2); one(T)])
+    ev[1] = -UX[1,1]*U[1,2]/(U[1,1]*U[2,2])+UX[1,2]/U[2,2] # this is dot(view(UX,1,1:2), U[1:2,1:2] \ [zero(T); one(T)])
+    ev[2] = UX[2,1]*(-U[1,3]/U[1,1])+U[1,2]*U[2,3]/(U[1,1]*U[2,2])/U[3,3]-UX[2,2]*U[2,3]/(U[2,2]*U[3,3])+UX[2,3]/U[3,3] # this is dot(view(UX,2,1:3), U[1:3,1:3] \ [zeros(T,2); one(T)])
     return QRJacobiBand{:ev,:R,T}(ev, U, UX, P, 2)
 end
 
@@ -236,7 +236,6 @@ function cache_filldata!(J::QRJacobiBand{:dv,:Q,T}, inds::UnitRange{Int}) where 
         K .= K .- τ[n] .*  v .* (v'K)
         K .= K .- τ[n] .*  (K*v) .* v'
         M = Matrix(X[n:n+b+1,n:n+b+1])
-        display(b+3)
         M[1:end-1,1:end-1] .= view(K,2:b+2,2:b+2)
         dv[n] = M[1,1] # sign correction due to QR not guaranteeing positive diagonal for R not needed on diagonals since contributions cancel
         K .= M

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -108,8 +108,6 @@ function _fillcholeskybanddata!(J::CholeskyJacobiData{T}, inds::UnitRange{Int}) 
         dv[k] = -U[k-1,k]*UX[k,k-1]/(U[k-1,k-1]*U[k,k])+UX[k,k]/U[k,k]
         ev[k] = UX[k,k-1]/U[k+1,k+1]*(-U[k-1,k+1]/U[k-1,k-1]+U[k-1,k]*U[k,k+1]/(U[k-1,k-1]*U[k,k]))+UX[k,k]/U[k+1,k+1]*(-U[k,k+1]/U[k,k])+UX[k,k+1]/U[k+1,k+1]  
     end
-    J.dv[inds] .= dv[inds]
-    J.ev[inds] .= ev[inds]
 end
 
 
@@ -224,14 +222,12 @@ function _fillqrbanddata!(J::QRJacobiData{:Q,T}, inds::UnitRange{Int}) where T
     @inbounds for n in jj
         dv[n] = K[1,1] # no sign correction needed on diagonal entry due to cancellation
         doublehouseholderapply!(K,τ[n+1],[zero(T);one(T);F[n+2:n+b+2,n+1]],w)
-        ev[n] = K[1,2]
+        ev[n] = K[1,2]*D[n] # contains sign correction from QR not forcing positive diagonals
         M .= view(X,n+1:n+b+3,n+1:n+b+3)
         M[1:end-1,1:end-1] .= view(K,2:b+3,2:b+3)
         K .= M
     end
     J.UX = M
-    J.dv[jj] .= dv[jj]
-    J.ev[jj] .= ev[jj].*D[jj] # contains sign correction from QR not forcing positive diagonals
 end
 
 function _fillqrbanddata!(J::QRJacobiData{:R,T}, inds::UnitRange{Int}) where T
@@ -245,6 +241,4 @@ function _fillqrbanddata!(J::QRJacobiData{:R,T}, inds::UnitRange{Int}) where T
         dv[k] = -U[k-1,k]*UX[k,k-1]/(U[k-1,k-1]*U[k,k])+UX[k,k]./U[k,k] # this is dot(view(UX,k,k-1:k), U[k-1:k,k-1:k] \ ek)
         ev[k] = UX[k,k-1]/U[k+1,k+1]*(-U[k-1,k+1]/U[k-1,k-1]+U[k-1,k]*U[k,k+1]/(U[k-1,k-1]*U[k,k]))+UX[k,k]/U[k+1,k+1]*(-U[k,k+1]/U[k,k])+UX[k,k+1]/U[k+1,k+1]  # this is dot(view(UX,k,k-1:k+1), U[k-1:k+1,k-1:k+1] \ ek)
     end
-    J.dv[inds] = dv[inds]
-    J.ev[inds] = ev[inds]
 end

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -245,7 +245,7 @@ function cache_filldata!(J::QRJacobiBand{:ev,:Q,T}, inds::UnitRange{Int}) where 
     X = jacobimatrix(J.P)[1:m+b+2,1:m+b+2]
     resizedata!(J.U.factors,m+b,m+b)
     resizedata!(J.U.R,m,m)
-    getindex(J.U.τ,m)
+    resizedata!(J.U.τ,m)
     M, τ, F, dv = J.UX, J.U.τ, J.U.factors, J.data
     D = sign.(view(J.U.R,band(0)).*view(J.U.R,band(0))[2:end])
     @inbounds for n in jj

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -163,7 +163,7 @@ function QRJacobiData{:Q,T}(F, P) where T
     # computes H*M*H in-place, overwriting M
     v = view(F.factors,2:b,2)
     reflectorApply!(v, F.τ[2], view(M,1,2:b))
-    reflectorApply!(v, F.τ[2], view(M,2:b,1))
+    M[1,2:b] .= view(M,1,2:b) # symmetric matrix, avoid recomputation
     reflectorApply!(v, F.τ[2], view(M,2:b,2:b))
     reflectorApply!(v, F.τ[2], view(M,2:b,2:b)')
     ev[1] = M[1,2]*sign(F.R[1,1]*F.R[2,2]) # includes possible correction for sign (only needed in off-diagonal case), since the QR decomposition does not guarantee positive diagonal on R
@@ -222,7 +222,7 @@ function _fillqrbanddata!(J::QRJacobiData{:Q,T}, inds::UnitRange{Int}) where T
         # doublehouseholderapply!(K,τ[n+1],view(F,n+2:n+b+2,n+1),w)
         v = view(F,n+1:n+b+2,n+1)
         reflectorApply!(v, τ[n+1], view(K,1,2:b+3))
-        reflectorApply!(v, τ[n+1], view(K,2:b+3,1))
+        M[1,2:b+3] .= view(M,1,2:b+3) # symmetric matrix, avoid recomputation
         reflectorApply!(v, τ[n+1], view(K,2:b+3,2:b+3))
         reflectorApply!(v, τ[n+1], view(K,2:b+3,2:b+3)')
         ev[n] = K[1,2]*D[n] # contains sign correction from QR not forcing positive diagonals

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -144,18 +144,6 @@ mutable struct QRJacobiData{method,T} <: AbstractMatrix{T}
     datasize::Int         # size of so-far computed block 
 end
 
-@inline function inplaceHouseholder!(x::AbstractVector, τ::Number, A::AbstractVecOrMat)
-    m, n = size(A, 1), size(A, 2)
-    m == 0 && return A
-    @inbounds for j = 1:n
-        Aj, xj = view(A, 2:m, j), view(x, 2:m)
-        vAj = conj(τ)*(A[1, j] + dot(xj, Aj))
-        A[1, j] -= vAj
-        axpy!(-vAj, xj, Aj)
-    end
-    return A
-end
-
 # Computes the initial data for the Jacobi operator bands
 function QRJacobiData{:Q,T}(F, P) where T
     b = 3+bandwidths(F.R)[2]÷2
@@ -168,16 +156,16 @@ function QRJacobiData{:Q,T}(F, P) where T
     resizedata!(F.factors,b,b)
     # special case for first entry double Householder product
     v = view(F.factors,1:b,1)
-    inplaceHouseholder!(v, F.τ[1], M)
-    inplaceHouseholder!(v, F.τ[1], M')
+    reflectorApply!(v, F.τ[1], M)
+    reflectorApply!(v, F.τ[1], M')
     dv[1] = M[1,1]
         # fill second entry
     # computes H*M*H in-place, overwriting M
     v = view(F.factors,2:b,2)
-    inplaceHouseholder!(v, F.τ[2], view(M,1,2:b))
+    reflectorApply!(v, F.τ[2], view(M,1,2:b))
     M[1,2:b] .= view(M,1,2:b) # symmetric matrix, avoid recomputation
-    inplaceHouseholder!(v, F.τ[2], view(M,2:b,2:b))
-    inplaceHouseholder!(v, F.τ[2], view(M,2:b,2:b)')
+    reflectorApply!(v, F.τ[2], view(M,2:b,2:b))
+    reflectorApply!(v, F.τ[2], view(M,2:b,2:b)')
     ev[1] = M[1,2]*sign(F.R[1,1]*F.R[2,2]) # includes possible correction for sign (only needed in off-diagonal case), since the QR decomposition does not guarantee positive diagonal on R
     K = Matrix(X[2:b+1,2:b+1])
     K[1:end-1,1:end-1] .= view(M,2:b,2:b)
@@ -233,10 +221,10 @@ function _fillqrbanddata!(J::QRJacobiData{:Q,T}, inds::UnitRange{Int}) where T
         dv[n] = K[1,1] # no sign correction needed on diagonal entry due to cancellation
         # doublehouseholderapply!(K,τ[n+1],view(F,n+2:n+b+2,n+1),w)
         v = view(F,n+1:n+b+2,n+1)
-        inplaceHouseholder!(v, τ[n+1], view(K,1,2:b+3))
+        reflectorApply!(v, τ[n+1], view(K,1,2:b+3))
         M[1,2:b+3] .= view(M,1,2:b+3) # symmetric matrix, avoid recomputation
-        inplaceHouseholder!(v, τ[n+1], view(K,2:b+3,2:b+3))
-        inplaceHouseholder!(v, τ[n+1], view(K,2:b+3,2:b+3)')
+        reflectorApply!(v, τ[n+1], view(K,2:b+3,2:b+3))
+        reflectorApply!(v, τ[n+1], view(K,2:b+3,2:b+3)')
         ev[n] = K[1,2]*D[n] # contains sign correction from QR not forcing positive diagonals
         M .= view(X,n+1:n+b+3,n+1:n+b+3)
         M[1:end-1,1:end-1] .= view(K,2:b+3,2:b+3)

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -146,10 +146,11 @@ end
 
 # computes H*M*H in-place, overwriting K
 function doublehouseholderapply!(M::AbstractMatrix{T}, τ::T, v, w) where T
-    mul!(w, M, [zero(T);one(T);v])  # M is symmetric
-    M .= M .- τ .* [zero(T);one(T);v] .* w'
-    mul!(w, M, [zero(T);one(T);v])
-    M .= M .- τ .* w .* [zero(T);one(T);v]'
+    k = [zero(T);one(T);v]
+    mul!(w, M, k)  # M is symmetric
+    M .= M .- τ .* k .* w'
+    mul!(w, M, k)
+    M .= M .- τ .* w .* k'
 end
 
 # Computes the initial data for the Jacobi operator bands

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -229,14 +229,15 @@ function cache_filldata!(J::QRJacobiBand{:dv,:Q,T}, inds::UnitRange{Int}) where 
     resizedata!(J.U.factors,m+b,m+b)
     resizedata!(J.U.τ,m)
     K, τ, F, dv = J.UX, J.U.τ, J.U.factors, J.data
-    v = Vector{T}(undef,b+3)
-    M = Matrix{T}(undef,b+3,b+3)
+    v = Vector{T}(undef,b+2)
+    M = Matrix{T}(undef,b+2,b+2)
     @inbounds for n in jj
         v = [zero(T);one(T);F[n+1:n+b,n]]
         K .= K .- τ[n] .*  v .* (v'K)
         K .= K .- τ[n] .*  (K*v) .* v'
         M = Matrix(X[n:n+b+1,n:n+b+1])
-        M[1:end-1,1:end-1] .= K[2:end,2:end]
+        display(b+3)
+        M[1:end-1,1:end-1] .= view(K,2:b+2,2:b+2)
         dv[n] = M[1,1] # sign correction due to QR not guaranteeing positive diagonal for R not needed on diagonals since contributions cancel
         K .= M
     end
@@ -261,7 +262,7 @@ function cache_filldata!(J::QRJacobiBand{:ev,:Q,T}, inds::UnitRange{Int}) where 
         K .= K .- τ[n+1] .*  (K*v) .* v'
         dv[n] = K[1,2]
         M .= Matrix(X[n+1:n+b+3,n+1:n+b+3])
-        M[1:end-1,1:end-1] .= K[2:end,2:end]
+        M[1:end-1,1:end-1] .= view(K,2:b+3,2:b+3)
         K .= M
     end
     J.UX = M

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -105,7 +105,7 @@ function _fillcholeskybanddata!(J::CholeskyJacobiData{T}, inds::UnitRange{Int}) 
     dv, ev, UX, U = J.dv, J.ev, J.UX, J.U
     @inbounds for k in inds
         # this is dot(view(UX,k,k-1:k), U[k-1:k,k-1:k] \ ek)
-        dv[k] = -U[k-1,k]*UX[k,k-1]/(U[k-1,k-1]*U[k,k])+UX[k,k]./U[k,k]
+        dv[k] = -U[k-1,k]*UX[k,k-1]/(U[k-1,k-1]*U[k,k])+UX[k,k]/U[k,k]
         ev[k] = UX[k,k-1]/U[k+1,k+1]*(-U[k-1,k+1]/U[k-1,k-1]+U[k-1,k]*U[k,k+1]/(U[k-1,k-1]*U[k,k]))+UX[k,k]/U[k+1,k+1]*(-U[k,k+1]/U[k,k])+UX[k,k+1]/U[k+1,k+1]  
     end
     J.dv[inds] .= dv[inds]

--- a/test/test_choleskyQR.jl
+++ b/test/test_choleskyQR.jl
@@ -119,7 +119,7 @@ import LazyArrays: AbstractCachedMatrix
         end
     end
 
-    @testset "Comparison of QR with Lanczos" begin
+    @testset "Comparison of QR with Classical and Lanczos" begin
         @testset "QR case, w(x) = (1-x)^2" begin
             P = Normalized(legendre(0..1))
             x = axes(P,1)
@@ -128,16 +128,60 @@ import LazyArrays: AbstractCachedMatrix
             sqrtwf(x) = (1-x)
             # compute Jacobi matrix via decomp
             Jchol = cholesky_jacobimatrix(wf, P)
-            Jqr = qr_jacobimatrix(sqrtwf, P)
+            JqrQ = qr_jacobimatrix(sqrtwf, P)
+            JqrR = qr_jacobimatrix(sqrtwf, P, :R)
             # use alternative inputs
             sqrtW = (P \ (sqrtwf.(x) .* P))
-            Jqralt = qr_jacobimatrix(sqrtW, P)
+            JqrQalt = qr_jacobimatrix(sqrtW, P)
+            JqrRalt = qr_jacobimatrix(sqrtW, P, :R)
             # compute Jacobi matrix via Lanczos
             Jlanc = jacobimatrix(LanczosPolynomial(@.(wf.(x)),Normalized(legendre(0..1))))
             # Comparison with Lanczos
             @test Jchol[1:500,1:500] ≈ Jlanc[1:500,1:500]
-            @test Jqr[1:500,1:500] ≈ Jlanc[1:500,1:500]
-            @test Jqralt[1:500,1:500] ≈ Jlanc[1:500,1:500]
+            @test JqrQ[1:500,1:500] ≈ Jlanc[1:500,1:500]
+            @test JqrR[1:500,1:500] ≈ Jlanc[1:500,1:500]
+            @test JqrQalt[1:500,1:500] ≈ Jlanc[1:500,1:500]
+            @test JqrRalt[1:500,1:500] ≈ Jlanc[1:500,1:500]
+        end
+        @testset "QR case, w(x) = (1-x)^4" begin
+            P = Normalized(legendre(0..1))
+            x = axes(P,1)
+            J = jacobimatrix(P)
+            sqrtwf(x) = (1-x)^2
+            # compute Jacobi matrix via decomp
+            JqrQ = qr_jacobimatrix(sqrtwf, P)
+            JqrR = qr_jacobimatrix(sqrtwf, P, :R)
+            # use alternative inputs
+            sqrtW = (P \ (sqrtwf.(x) .* P))
+            JqrQalt = qr_jacobimatrix(sqrtW, P)
+            JqrRalt = qr_jacobimatrix(sqrtW, P, :R)
+            # compute Jacobi matrix via Lanczos
+            Jclass = jacobimatrix(Normalized(jacobi(4,0,0..1)))
+            # Comparison with Lanczos
+            @test JqrQ[1:10,1:10] ≈ Jclass[1:10,1:10]
+            @test JqrR[1:10,1:10] ≈ Jclass[1:10,1:10]
+            @test JqrQalt[1:10,1:10] ≈ Jclass[1:10,1:10]
+            @test JqrRalt[1:10,1:10] ≈ Jclass[1:10,1:10]
+        end
+        @testset "QR case, w(x) = (1+x)^2*(1-x)^4" begin
+            P = Normalized(legendre(0..1))
+            x = axes(P,1)
+            J = jacobimatrix(P)
+            sqrtwf(x) = (x)*(1-x)^2
+            # compute Jacobi matrix via decomp
+            JqrQ = qr_jacobimatrix(sqrtwf, P)
+            JqrR = qr_jacobimatrix(sqrtwf, P, :R)
+            # use alternative inputs
+            sqrtW = (P \ (sqrtwf.(x) .* P))
+            JqrQalt = qr_jacobimatrix(sqrtW, P)
+            JqrRalt = qr_jacobimatrix(sqrtW, P, :R)
+            # compute Jacobi matrix via Lanczos
+            Jclass = jacobimatrix(Normalized(jacobi(4,2,0..1)))
+            # Comparison with Lanczos
+            @test JqrQ[1:10,1:10] ≈ Jclass[1:10,1:10]
+            @test JqrR[1:10,1:10] ≈ Jclass[1:10,1:10]
+            @test JqrQalt[1:10,1:10] ≈ Jclass[1:10,1:10]
+            @test JqrRalt[1:10,1:10] ≈ Jclass[1:10,1:10]
         end
     end
 

--- a/test/test_choleskyQR.jl
+++ b/test/test_choleskyQR.jl
@@ -163,7 +163,7 @@ import LazyArrays: AbstractCachedMatrix
             @test JqrQalt[1:10,1:10] ≈ Jclass[1:10,1:10]
             @test JqrRalt[1:10,1:10] ≈ Jclass[1:10,1:10]
         end
-        @testset "QR case, w(x) = (1+x)^2*(1-x)^4" begin
+        @testset "QR case, w(x) = (x)^2*(1-x)^4" begin
             P = Normalized(legendre(0..1))
             x = axes(P,1)
             J = jacobimatrix(P)

--- a/test/test_choleskyQR.jl
+++ b/test/test_choleskyQR.jl
@@ -213,6 +213,3 @@ import LazyArrays: AbstractCachedMatrix
         @test_broken R[1:10,1:10] isa BandedMatrix
     end
 end
-
-
-

--- a/test/test_choleskyQR.jl
+++ b/test/test_choleskyQR.jl
@@ -213,3 +213,6 @@ import LazyArrays: AbstractCachedMatrix
         @test_broken R[1:10,1:10] isa BandedMatrix
     end
 end
+
+
+

--- a/test/test_choleskyQR.jl
+++ b/test/test_choleskyQR.jl
@@ -1,6 +1,6 @@
 using Test, ClassicalOrthogonalPolynomials, BandedMatrices, LinearAlgebra, LazyArrays, ContinuumArrays, LazyBandedMatrices, InfiniteLinearAlgebra
 import ClassicalOrthogonalPolynomials: cholesky_jacobimatrix, qr_jacobimatrix
-import LazyArrays: AbstractCachedMatrix
+import LazyArrays: AbstractCachedMatrix, resizedata!
 
 
 @testset "CholeskyQR" begin

--- a/test/test_choleskyQR.jl
+++ b/test/test_choleskyQR.jl
@@ -182,6 +182,11 @@ import LazyArrays: AbstractCachedMatrix
             @test JqrR[1:10,1:10] ≈ Jclass[1:10,1:10]
             @test JqrQalt[1:10,1:10] ≈ Jclass[1:10,1:10]
             @test JqrRalt[1:10,1:10] ≈ Jclass[1:10,1:10]
+            # test consistency of resizing in succession
+            F = qr_jacobimatrix(sqrtwf, P);
+            @test JqrQ[1:5,1:5] ≈ F[1:5,1:5]
+            @test JqrQ[1:20,1:20] ≈ F[1:20,1:20]
+            @test JqrQ[50:70,50:70] ≈ F[50:70,50:70]
         end
     end
 

--- a/test/test_choleskyQR.jl
+++ b/test/test_choleskyQR.jl
@@ -184,6 +184,8 @@ import LazyArrays: AbstractCachedMatrix
             @test JqrRalt[1:10,1:10] ≈ Jclass[1:10,1:10]
             # test consistency of resizing in succession
             F = qr_jacobimatrix(sqrtwf, P);
+            resizedata!(JqrQ.dv,70)
+            resizedata!(JqrQ.ev,70)
             @test JqrQ[1:5,1:5] ≈ F[1:5,1:5]
             @test JqrQ[1:20,1:20] ≈ F[1:20,1:20]
             @test JqrQ[50:70,50:70] ≈ F[50:70,50:70]


### PR DESCRIPTION
@ioannisPApapadopoulos @dlfivefifty 

This PR adds an optional `method` argument to `qr_jacobimatrix()` which allows either `:Q` or `:R` as input and will do the QR raising using the chosen matrix, both in `O(n)`. The default if no method is supplied is to use `:Q`. 

The Q method more or less matches the R method in efficiency (some efficiency is lost to make sure the resulting matrix fits into an adaptive SymTridiagonal but this is also true for the R approach) - there is more optimization that could be done in principle but I am not sure it's worth it considering we can do this:

```julia
julia> P = Normalized(legendre(0..1));

julia> x = axes(P,1);

julia> J = jacobimatrix(P);

julia> wf(x) = (1-x)^2;

julia> sqrtwf(x) = (1-x);

julia> Jchol = cholesky_jacobimatrix(wf, P);

julia> JqrQ = qr_jacobimatrix(sqrtwf, P);

julia> JqrR = qr_jacobimatrix(sqrtwf, P, :R);

julia> N = 100_000
100000

julia> @time Jchol[1:N,1:N]
  1.015375 seconds (13.59 M allocations: 988.733 MiB, 11.53% gc time)
100000×100000 BandedMatrix{Float64} with bandwidths (1, 1):
 0.25      0.193649   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅       …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
 0.193649  0.416667  0.225374   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅        0.225374  0.458333  0.236228   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅        0.236228  0.475     0.241209   ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅        0.241209  0.483333  0.243904   ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅        0.243904  0.488095  0.245525   ⋅         ⋅         ⋅       …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅        0.245525  0.491071  0.246576   ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.246576  0.493056  0.247296   ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.247296  0.494444  0.24781      ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
 ⋮                                                 ⋮                                                ⋱                 ⋮                        ⋮                            ⋮                       
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.25  0.5   0.25   ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    0.25  0.5   0.25   ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅    0.25  0.5   0.25   ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅       …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅    0.25  0.5   0.25   ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅    0.25  0.5   0.25   ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅    0.25  0.5   0.25   ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.25  0.5   0.25
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.25  0.5

julia> @time JqrQ[1:N,1:N]
  1.347002 seconds (21.48 M allocations: 1.476 GiB, 12.26% gc time)
100000×100000 BandedMatrix{Float64} with bandwidths (1, 1):
 0.25      0.193649   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅       …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
 0.193649  0.416667  0.225374   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅        0.225374  0.458333  0.236228   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅        0.236228  0.475     0.241209   ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅        0.241209  0.483333  0.243904   ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅        0.243904  0.488095  0.245525   ⋅         ⋅         ⋅       …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅        0.245525  0.491071  0.246576   ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.246576  0.493056  0.247296   ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.247296  0.494444  0.24781      ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
 ⋮                                                 ⋮                                                ⋱                 ⋮                        ⋮                            ⋮                       
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.25  0.5   0.25   ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    0.25  0.5   0.25   ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅    0.25  0.5   0.25   ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅       …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅    0.25  0.5   0.25   ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅    0.25  0.5   0.25   ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅    0.25  0.5   0.25   ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.25  0.5   0.25
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.25  0.5

julia> @time JqrR[1:N,1:N]
  1.179295 seconds (16.09 M allocations: 1.229 GiB, 11.27% gc time)
100000×100000 BandedMatrix{Float64} with bandwidths (1, 1):
 0.25      0.193649   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅       …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
 0.193649  0.416667  0.225374   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅        0.225374  0.458333  0.236228   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅        0.236228  0.475     0.241209   ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅        0.241209  0.483333  0.243904   ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅        0.243904  0.488095  0.245525   ⋅         ⋅         ⋅       …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅        0.245525  0.491071  0.246576   ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.246576  0.493056  0.247296   ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.247296  0.494444  0.24781      ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
 ⋮                                                 ⋮                                                ⋱                 ⋮                        ⋮                            ⋮                       
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.25  0.5   0.25   ⋅     ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    0.25  0.5   0.25   ⋅     ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅    0.25  0.5   0.25   ⋅     ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅       …   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅    0.25  0.5   0.25   ⋅     ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅    0.25  0.5   0.25   ⋅     ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅    0.25  0.5   0.25   ⋅ 
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.25  0.5   0.25
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅           ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    0.25  0.5
```

Once this is done I will change my PR in SemiclassicalOPs to use this approach for the hierarchy.