### PR TITLE
BigFloat compatibility for qr_jacobimatrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClassicalOrthogonalPolynomials"
 uuid = "b30e2e7b-c4ee-47da-9d5f-2c5c27239acd"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.11"
+version = "0.11.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -219,10 +219,10 @@ function _fillqrbanddata!(J::QRJacobiData{:Q,T}, inds::UnitRange{Int}) where T
     K, τ, F, dv, ev = J.UX, J.U.τ, J.U.factors, J.dv, J.ev
     D = sign.(view(J.U.R,band(0)).*view(J.U.R,band(0))[2:end])
     M = zeros(T,b+3,b+3)
-    if T == BigFloat
-        M = zeros(T,b+3,b+3)
-    else
+    if isprimitivetype(T)
         M = Matrix{T}(undef,b+3,b+3) 
+    else
+        M = zeros(T,b+3,b+3)
     end
     @inbounds for n in jj
         dv[n] = K[1,1] # no sign correction needed on diagonal entry due to cancellation

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -66,8 +66,14 @@ end
 
 # Computes the initial data for the Jacobi operator bands
 function CholeskyJacobiData(U::AbstractMatrix{T}, UX) where T
-    dv = Vector{T}(undef,2) # compute a length 2 vector on first go
-    ev = Vector{T}(undef,2)
+    # compute a length 2 vector on first go and circumvent BigFloat issue
+    if T isa BigFloat
+        dv = zeros(T,2) 
+        ev = zeros(T,2)
+    else
+        dv = Vector{T}(undef,2) 
+        ev = Vector{T}(undef,2) 
+    end
     dv[1] = UX[1,1]/U[1,1] # this is dot(view(UX,1,1), U[1,1] \ [one(T)])
     dv[2] = -U[1,2]*UX[2,1]/(U[1,1]*U[2,2])+UX[2,2]/U[2,2] # this is dot(view(UX,2,1:2), U[1:2,1:2] \ [zero(T); one(T)])
     ev[1] = -UX[1,1]*U[1,2]/(U[1,1]*U[2,2])+UX[1,2]/U[2,2] # this is dot(view(UX,1,1:2), U[1:2,1:2] \ [zero(T); one(T)])
@@ -148,9 +154,14 @@ end
 function QRJacobiData{:Q,T}(F, P) where T
     b = 3+bandwidths(F.R)[2]÷2
     X = jacobimatrix(P)
-        # we fill 1 entry on the first run
-    dv = zeros(T,2)
-    ev = zeros(T,1)
+        # we fill 1 entry on the first run and circumvent BigFloat issue
+    if T isa BigFloat
+        dv = zeros(T,2) 
+        ev = zeros(T,1)
+    else
+        dv = Vector{T}(undef,2) 
+        ev = Vector{T}(undef,1) 
+    end
         # fill first entry (special case)
     M = Matrix(X[1:b,1:b])
     resizedata!(F.factors,b,b)
@@ -176,8 +187,14 @@ function QRJacobiData{:R,T}(F, P) where T
     U = ApplyArray(*,Diagonal(sign.(view(U,band(0)))),U)  # QR decomposition does not force positive diagonals on R by default
     X = jacobimatrix(P)
     UX = ApplyArray(*,U,X)
-    dv = Vector{T}(undef,2) # compute a length 2 vector on first go
-    ev = Vector{T}(undef,2)
+    # compute a length 2 vector on first go and circumvent BigFloat issue
+    if T isa BigFloat
+        dv = zeros(T,2) 
+        ev = zeros(T,2)
+    else
+        dv = Vector{T}(undef,2) 
+        ev = Vector{T}(undef,2) 
+    end
     dv[1] = UX[1,1]/U[1,1] # this is dot(view(UX,1,1), U[1,1] \ [one(T)])
     dv[2] = -U[1,2]*UX[2,1]/(U[1,1]*U[2,2])+UX[2,2]/U[2,2] # this is dot(view(UX,2,1:2), U[1:2,1:2] \ [zero(T); one(T)])
     ev[1] = -UX[1,1]*U[1,2]/(U[1,1]*U[2,2])+UX[1,2]/U[2,2] # this is dot(view(UX,1,1:2), U[1:2,1:2] \ [zero(T); one(T)])
@@ -216,7 +233,12 @@ function _fillqrbanddata!(J::QRJacobiData{:Q,T}, inds::UnitRange{Int}) where T
     resizedata!(J.U.τ,m)
     K, τ, F, dv, ev = J.UX, J.U.τ, J.U.factors, J.dv, J.ev
     D = sign.(view(J.U.R,band(0)).*view(J.U.R,band(0))[2:end])
-    M = Matrix{T}(undef,b+3,b+3)
+    M = zeros(T,b+3,b+3)
+    if T isa BigFloat
+        M = zeros(T,b+3,b+3)
+    else
+        M = Matrix{T}(undef,b+3,b+3) 
+    end
     @inbounds for n in jj
         dv[n] = K[1,1] # no sign correction needed on diagonal entry due to cancellation
         # doublehouseholderapply!(K,τ[n+1],view(F,n+2:n+b+2,n+1),w)

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -67,7 +67,7 @@ end
 # Computes the initial data for the Jacobi operator bands
 function CholeskyJacobiData(U::AbstractMatrix{T}, UX) where T
     # compute a length 2 vector on first go and circumvent BigFloat issue
-    if T isa BigFloat
+    if T == BigFloat
         dv = zeros(T,2) 
         ev = zeros(T,2)
     else
@@ -155,7 +155,7 @@ function QRJacobiData{:Q,T}(F, P) where T
     b = 3+bandwidths(F.R)[2]÷2
     X = jacobimatrix(P)
         # we fill 1 entry on the first run and circumvent BigFloat issue
-    if T isa BigFloat
+    if T == BigFloat
         dv = zeros(T,2) 
         ev = zeros(T,1)
     else
@@ -188,7 +188,7 @@ function QRJacobiData{:R,T}(F, P) where T
     X = jacobimatrix(P)
     UX = ApplyArray(*,U,X)
     # compute a length 2 vector on first go and circumvent BigFloat issue
-    if T isa BigFloat
+    if T == BigFloat
         dv = zeros(T,2) 
         ev = zeros(T,2)
     else
@@ -234,7 +234,7 @@ function _fillqrbanddata!(J::QRJacobiData{:Q,T}, inds::UnitRange{Int}) where T
     K, τ, F, dv, ev = J.UX, J.U.τ, J.U.factors, J.dv, J.ev
     D = sign.(view(J.U.R,band(0)).*view(J.U.R,band(0))[2:end])
     M = zeros(T,b+3,b+3)
-    if T isa BigFloat
+    if T == BigFloat
         M = zeros(T,b+3,b+3)
     else
         M = Matrix{T}(undef,b+3,b+3) 

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -67,13 +67,8 @@ end
 # Computes the initial data for the Jacobi operator bands
 function CholeskyJacobiData(U::AbstractMatrix{T}, UX) where T
     # compute a length 2 vector on first go and circumvent BigFloat issue
-    if T == BigFloat
-        dv = zeros(T,2) 
-        ev = zeros(T,2)
-    else
-        dv = Vector{T}(undef,2) 
-        ev = Vector{T}(undef,2) 
-    end
+    dv = zeros(T,2) 
+    ev = zeros(T,2)
     dv[1] = UX[1,1]/U[1,1] # this is dot(view(UX,1,1), U[1,1] \ [one(T)])
     dv[2] = -U[1,2]*UX[2,1]/(U[1,1]*U[2,2])+UX[2,2]/U[2,2] # this is dot(view(UX,2,1:2), U[1:2,1:2] \ [zero(T); one(T)])
     ev[1] = -UX[1,1]*U[1,2]/(U[1,1]*U[2,2])+UX[1,2]/U[2,2] # this is dot(view(UX,1,1:2), U[1:2,1:2] \ [zero(T); one(T)])
@@ -154,15 +149,10 @@ end
 function QRJacobiData{:Q,T}(F, P) where T
     b = 3+bandwidths(F.R)[2]÷2
     X = jacobimatrix(P)
-        # we fill 1 entry on the first run and circumvent BigFloat issue
-    if T == BigFloat
-        dv = zeros(T,2) 
-        ev = zeros(T,1)
-    else
-        dv = Vector{T}(undef,2) 
-        ev = Vector{T}(undef,1) 
-    end
-        # fill first entry (special case)
+    # we fill 1 entry on the first run and circumvent BigFloat issue
+    dv = zeros(T,2) 
+    ev = zeros(T,1)
+    # fill first entry (special case)
     M = Matrix(X[1:b,1:b])
     resizedata!(F.factors,b,b)
     # special case for first entry double Householder product
@@ -188,13 +178,8 @@ function QRJacobiData{:R,T}(F, P) where T
     X = jacobimatrix(P)
     UX = ApplyArray(*,U,X)
     # compute a length 2 vector on first go and circumvent BigFloat issue
-    if T == BigFloat
-        dv = zeros(T,2) 
-        ev = zeros(T,2)
-    else
-        dv = Vector{T}(undef,2) 
-        ev = Vector{T}(undef,2) 
-    end
+    dv = zeros(T,2) 
+    ev = zeros(T,2)
     dv[1] = UX[1,1]/U[1,1] # this is dot(view(UX,1,1), U[1,1] \ [one(T)])
     dv[2] = -U[1,2]*UX[2,1]/(U[1,1]*U[2,2])+UX[2,2]/U[2,2] # this is dot(view(UX,2,1:2), U[1:2,1:2] \ [zero(T); one(T)])
     ev[1] = -UX[1,1]*U[1,2]/(U[1,1]*U[2,2])+UX[1,2]/U[2,2] # this is dot(view(UX,1,1:2), U[1:2,1:2] \ [zero(T); one(T)])

--- a/test/test_choleskyQR.jl
+++ b/test/test_choleskyQR.jl
@@ -205,9 +205,10 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
             @test JqrQ[1:20,1:20] ≈ F[1:20,1:20]
             @test JqrQ[50:70,50:70] ≈ F[50:70,50:70]
         end
-        @testset "BigFloat returns correct values"
+        @testset "BigFloat returns correct values" begin
             t = BigFloat("1.1")
             P = Normalized(legendre(big(0)..big(1)))
+            X = jacobimatrix(P)
             Xq = qr_jacobimatrix(t*I-X, P, :Q)
             Xr = qr_jacobimatrix(t*I-X, P, :R)
             @test Xq[1:20,1:20] ≈ Xr[1:20,1:20]

--- a/test/test_choleskyQR.jl
+++ b/test/test_choleskyQR.jl
@@ -205,6 +205,14 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
             @test JqrQ[1:20,1:20] ≈ F[1:20,1:20]
             @test JqrQ[50:70,50:70] ≈ F[50:70,50:70]
         end
+        @testset "BigFloat returns correct values"
+            t = BigFloat("1.1")
+            P = Normalized(legendre(big(0)..big(1)))
+            Xq = qr_jacobimatrix(t*I-X, P, :Q)
+            Xr = qr_jacobimatrix(t*I-X, P, :R)
+            @test Xq[1:20,1:20] ≈ Xr[1:20,1:20]
+            @test_broken Xq[1:20,1:20] ≈ cholesky_jacobimatrix(Symmetric((t*I-X)^2), P)[1:20,1:20]
+        end
     end
 
     @testset "ConvertedOP" begin


### PR DESCRIPTION
@dlfivefifty @MikaelSlevinsky  This PR restores BigFloat compatibility to the QR variants of jacobimatrix computation. The fix in theory also addresses Cholesky but that remains broken because of a similar issue in InfiniteLinearAlgebra.jl exemplified by 

```julia
julia> P = Normalized(legendre(big(0)..big(1)))
Normalized(Legendre{BigFloat}() affine mapped to 0..1)

julia> X = jacobimatrix(P)
ℵ₀×ℵ₀ LazyBandedMatrices.SymTridiagonal{BigFloat, Fill{BigFloat, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, BroadcastVector{BigFloat, typeof(sqrt), Tuple{BroadcastVector{BigFloat, typeof(*), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}, BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}}}}}} with indices OneToInf()×OneToInf():
 0.5       0.288675   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅       …  
 0.288675  0.5       0.258199   ⋅         ⋅         ⋅         ⋅         ⋅          
  ⋅        0.258199  0.5       0.253546   ⋅         ⋅         ⋅         ⋅          
  ⋅         ⋅        0.253546  0.5       0.251976   ⋅         ⋅         ⋅          
  ⋅         ⋅         ⋅        0.251976  0.5       0.251259   ⋅         ⋅          
  ⋅         ⋅         ⋅         ⋅        0.251259  0.5       0.250873   ⋅       …  
  ⋅         ⋅         ⋅         ⋅         ⋅        0.250873  0.5       0.25064     
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.25064   0.5         
  ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.25049     
 ⋮                                                 ⋮                            ⋱  

julia> cholesky(Symmetric(X^2)).U[1,1]
ERROR: UndefRefError: access to undefined reference
Stacktrace:
  [1] getindex
    @ ./essentials.jl:14 [inlined]
  [2] getindex
    @ ./subarray.jl:286 [inlined]
  [3] _getindex
    @ ./abstractarray.jl:1344 [inlined]
  [4] getindex
    @ ./abstractarray.jl:1294 [inlined]
  [5] macro expansion
    @ ~/Documents/Backends/julia-1.9.0/share/julia/stdlib/v1.9/LinearAlgebra/src/generic.jl:221 [inlined]
  [6] macro expansion
    @ ./simdloop.jl:77 [inlined]
  [7] lmul!(s::BigFloat, X::SubArray{BigFloat, 2, Matrix{BigFloat}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false})
    @ LinearAlgebra ~/Documents/Backends/julia-1.9.0/share/julia/stdlib/v1.9/LinearAlgebra/src/generic.jl:220
  [8] _banded_lmul!
    @ ~/.julia/packages/BandedMatrices/qLIMl/src/generic/broadcast.jl:938 [inlined]
  [9] banded_lmul!
    @ ~/.julia/packages/BandedMatrices/qLIMl/src/generic/broadcast.jl:947 [inlined]
 [10] materialize!
    @ ~/.julia/packages/BandedMatrices/qLIMl/src/generic/broadcast.jl:950 [inlined]
 [11] #lmul!#10
    @ ~/.julia/packages/ArrayLayouts/3K92Y/src/lmul.jl:47 [inlined]
 [12] lmul!
    @ ~/.julia/packages/ArrayLayouts/3K92Y/src/lmul.jl:47 [inlined]
 [13] default_blasmul!(α::BigFloat, A::Adjoint{BigFloat, SubArray{BigFloat, 2, BandedMatrix{BigFloat, Matrix{BigFloat}, Base.OneTo{Int64}}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}}, B::SubArray{BigFloat, 2, BandedMatrix{BigFloat, Matrix{BigFloat}, Base.OneTo{Int64}}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}, β::BigFloat, C::SubArray{BigFloat, 2, BandedMatrix{BigFloat, Matrix{BigFloat}, Base.OneTo{Int64}}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false})
    @ ArrayLayouts ~/.julia/packages/ArrayLayouts/3K92Y/src/muladd.jl:172
 [14] materialize!(M::ArrayLayouts.MulAdd{BandedMatrices.BandedRows{ArrayLayouts.DenseColumnMajor}, BandedMatrices.BandedColumns{ArrayLayouts.DenseColumnMajor}, BandedMatrices.BandedColumns{ArrayLayouts.DenseColumnMajor}, BigFloat, Adjoint{BigFloat, SubArray{BigFloat, 2, BandedMatrix{BigFloat, Matrix{BigFloat}, Base.OneTo{Int64}}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}}, SubArray{BigFloat, 2, BandedMatrix{BigFloat, Matrix{BigFloat}, Base.OneTo{Int64}}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}, SubArray{BigFloat, 2, BandedMatrix{BigFloat, Matrix{BigFloat}, Base.OneTo{Int64}}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}})
    @ ArrayLayouts ~/.julia/packages/ArrayLayouts/3K92Y/src/muladd.jl:241
 [15] muladd!
    @ ~/.julia/packages/ArrayLayouts/3K92Y/src/muladd.jl:70 [inlined]
 [16] partialcholesky!(F::InfiniteLinearAlgebra.AdaptiveCholeskyFactors{BigFloat, BandedMatrix{BigFloat, Matrix{BigFloat}, Base.OneTo{Int64}}, ApplyArray{BigFloat, 2, typeof(*), Tuple{LazyBandedMatrices.SymTridiagonal{BigFloat, Fill{BigFloat, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, BroadcastVector{BigFloat, typeof(sqrt), Tuple{BroadcastVector{BigFloat, typeof(*), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}, BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}}}}}}, LazyBandedMatrices.SymTridiagonal{BigFloat, Fill{BigFloat, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, BroadcastVector{BigFloat, typeof(sqrt), Tuple{BroadcastVector{BigFloat, typeof(*), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}, BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}}}}}}}}}, n::Int64)
    @ InfiniteLinearAlgebra ~/.julia/packages/InfiniteLinearAlgebra/y1GuF/src/infcholesky.jl:35
 [17] getindex(F::InfiniteLinearAlgebra.AdaptiveCholeskyFactors{BigFloat, BandedMatrix{BigFloat, Matrix{BigFloat}, Base.OneTo{Int64}}, ApplyArray{BigFloat, 2, typeof(*), Tuple{LazyBandedMatrices.SymTridiagonal{BigFloat, Fill{BigFloat, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, BroadcastVector{BigFloat, typeof(sqrt), Tuple{BroadcastVector{BigFloat, typeof(*), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}, BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}}}}}}, LazyBandedMatrices.SymTridiagonal{BigFloat, Fill{BigFloat, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, BroadcastVector{BigFloat, typeof(sqrt), Tuple{BroadcastVector{BigFloat, typeof(*), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}, BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}}}}}}}}}, k::Int64, j::Int64)
    @ InfiniteLinearAlgebra ~/.julia/packages/InfiniteLinearAlgebra/y1GuF/src/infcholesky.jl:42
 [18] getindex(A::UpperTriangular{BigFloat, InfiniteLinearAlgebra.AdaptiveCholeskyFactors{BigFloat, BandedMatrix{BigFloat, Matrix{BigFloat}, Base.OneTo{Int64}}, ApplyArray{BigFloat, 2, typeof(*), Tuple{LazyBandedMatrices.SymTridiagonal{BigFloat, Fill{BigFloat, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, BroadcastVector{BigFloat, typeof(sqrt), Tuple{BroadcastVector{BigFloat, typeof(*), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}, BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}}}}}}, LazyBandedMatrices.SymTridiagonal{BigFloat, Fill{BigFloat, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, BroadcastVector{BigFloat, typeof(sqrt), Tuple{BroadcastVector{BigFloat, typeof(*), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}, BroadcastVector{BigFloat, typeof(/), Tuple{BroadcastVector{BigFloat, typeof(/), Tuple{InfiniteArrays.InfStepRange{BigFloat, BigFloat}, InfiniteArrays.InfStepRange{Int64, Int64}}}, BigFloat}}}}}}}}}}}, i::Int64, j::Int64)
    @ LinearAlgebra ~/Documents/Backends/julia-1.9.0/share/julia/stdlib/v1.9/LinearAlgebra/src/triangular.jl:232
 [19] top-level scope
 ```

Once that is fixed we can remove the `_broken` from the test added here.