### PR TITLE
Speed up Cholesky Jacobi matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClassicalOrthogonalPolynomials"
 uuid = "b30e2e7b-c4ee-47da-9d5f-2c5c27239acd"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.12.3"
+version = "0.12.4"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/ClassicalOrthogonalPolynomials.jl
+++ b/src/ClassicalOrthogonalPolynomials.jl
@@ -33,7 +33,7 @@ import QuasiArrays: cardinality, checkindex, QuasiAdjoint, QuasiTranspose, Inclu
                     AbstractQuasiFill, equals_layout, QuasiArrayLayout, PolynomialLayout, diff_layout
 
 import InfiniteArrays: OneToInf, InfAxes, Infinity, AbstractInfUnitRange, InfiniteCardinal, InfRanges
-import InfiniteLinearAlgebra: chop!, chop, pad, choplength, compatible_resize!
+import InfiniteLinearAlgebra: chop!, chop, pad, choplength, compatible_resize!, partialcholesky!
 import ContinuumArrays: Basis, Weight, basis_axes, @simplify, Identity, AbstractAffineQuasiVector, ProjectionFactorization,
     grid, plotgrid, plotgrid_layout, plotvalues_layout, grid_layout, transform_ldiv, TransformFactorization, QInfAxes, broadcastbasis, ExpansionLayout, basismap,
     AffineQuasiVector, AffineMap, AbstractWeightLayout, AbstractWeightedBasisLayout, WeightedBasisLayout, WeightedBasisLayouts, demap, AbstractBasisLayout, BasisLayout,

--- a/src/ClassicalOrthogonalPolynomials.jl
+++ b/src/ClassicalOrthogonalPolynomials.jl
@@ -17,7 +17,7 @@ import LazyArrays: MemoryLayout, Applied, ApplyStyle, flatten, _flatten, adjoint
                 sub_materialize, arguments, sub_paddeddata, paddeddata, PaddedLayout, resizedata!, LazyVector, ApplyLayout, call,
                 _mul_arguments, CachedVector, CachedMatrix, LazyVector, LazyMatrix, axpy!, AbstractLazyLayout, BroadcastLayout,
                 AbstractCachedVector, AbstractCachedMatrix, paddeddata, cache_filldata!,
-                simplifiable, PaddedArray, converteltype
+                simplifiable, PaddedArray, converteltype, simplify
 import ArrayLayouts: MatMulVecAdd, materialize!, _fill_lmul!, sublayout, sub_materialize, lmul!, ldiv!, ldiv, transposelayout, triangulardata,
                         subdiagonaldata, diagonaldata, supdiagonaldata, mul, rowsupport, colsupport
 import LazyBandedMatrices: SymTridiagonal, Bidiagonal, Tridiagonal, unitblocks, BlockRange1, AbstractLazyBandedLayout

--- a/src/choleskyQR.jl
+++ b/src/choleskyQR.jl
@@ -72,6 +72,7 @@ function CholeskyJacobiData(U::AbstractMatrix{T}, P) where T
     dv = zeros(T,2)
     ev = zeros(T,2)
     X = jacobimatrix(P)
+    partialcholesky!(U.data, 3)
     UX = view(U,1:3,1:3)*X[1:3,1:3]
     dv[1] = UX[1,1]/U[1,1] # this is dot(view(UX,1,1), U[1,1] \ [one(T)])
     dv[2] = -U[1,2]*UX[2,1]/(U[1,1]*U[2,2])+UX[2,2]/U[2,2] # this is dot(view(UX,2,1:2), U[1:2,1:2] \ [zero(T); one(T)])

--- a/src/clenshaw.jl
+++ b/src/clenshaw.jl
@@ -289,7 +289,7 @@ function _BandedMatrix(::ClenshawLayout, V::SubArray{<:Any,2})
     M = parent(V)
     kr,jr = parentindices(V)
     b = bandwidth(M,1)
-    jkr=max(1,min(first(jr),first(kr))-b÷2):max(last(jr),last(kr))+b÷2
+    jkr = max(1,min(first(jr),first(kr))-b÷2):max(last(jr),last(kr))+b÷2
     # relationship between jkr and kr, jr
     kr2,jr2 = kr.-first(jkr).+1,jr.-first(jkr).+1
     lmul!(M.p0, clenshaw(M.c, M.A, M.B, M.C, M.X[jkr, jkr])[kr2,jr2])
@@ -297,7 +297,7 @@ end
 
 function getindex(M::Clenshaw{T}, kr::AbstractUnitRange, j::Integer) where T
     b = bandwidth(M,1)
-    jkr=max(1,min(j,first(kr))-b÷2):max(j,last(kr))+b÷2
+    jkr = max(1,min(j,first(kr))-b÷2):max(j,last(kr))+b÷2
     # relationship between jkr and kr, jr
     kr2,j2 = kr.-first(jkr).+1,j-first(jkr)+1
     f = [Zeros{T}(j2-1); one(T); Zeros{T}(length(jkr)-j2)]
@@ -310,7 +310,7 @@ getindex(M::Clenshaw, k::Int, j::Int) = M[k:k,j][1]
 function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, j::Integer) where T
     M = S.data
     b = bandwidth(M,1)
-    jkr=max(1,min(j,first(kr))-b÷2):max(j,last(kr))+b÷2
+    jkr = max(1,min(j,first(kr))-b÷2):max(j,last(kr))+b÷2
     # relationship between jkr and kr, jr
     kr2,j2 = kr.-first(jkr).+1,j-first(jkr)+1
     f = [Zeros{T}(j2-1); one(T); Zeros{T}(length(jkr)-j2)]
@@ -320,7 +320,7 @@ end
 function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, jr::AbstractUnitRange) where T
     M = S.data
     b = bandwidth(M,1)
-    jkr=max(1,min(first(jr),first(kr))-b÷2):max(last(jr),last(kr))+b÷2
+    jkr = max(1,min(first(jr),first(kr))-b÷2):max(last(jr),last(kr))+b÷2
     # relationship between jkr and kr, jr
     kr2,jr2 = kr.-first(jkr).+1,jr.-first(jkr).+1
     Symmetric(lmul!(M.p0, clenshaw(M.c, M.A, M.B, M.C, M.X[jkr, jkr])[minimum(min(jr2,kr2)):maximum(max(jr2,kr2)),minimum(min(jr2,kr2)):maximum(max(jr2,kr2))]))[kr2,jr2]

--- a/src/clenshaw.jl
+++ b/src/clenshaw.jl
@@ -306,7 +306,7 @@ end
 
 getindex(M::Clenshaw, k::Int, j::Int) = M[k:k,j][1]
 
-function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, k::Integer, jr::AbstractUnitRange) where T
+function getindex(S::Symmetric{T,<:Clenshaw}, k::Integer, jr::AbstractUnitRange) where T
     m = max(jr.start,jr.stop,k)
     return Symmetric(getindex(S.data,1:m,1:m),Symbol(S.uplo))[k,jr]
 end

--- a/src/clenshaw.jl
+++ b/src/clenshaw.jl
@@ -314,7 +314,7 @@ function getindex(S::Symmetric{T,<:Clenshaw}, kr::AbstractUnitRange, j::Integer)
     m = max(kr.start,kr.stop,j)
     return Symmetric(getindex(S.data,1:m,1:m),Symbol(S.uplo))[kr,j]
 end
-function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, jr::AbstractUnitRange) where T
+function getindex(S::Symmetric{T,<:Clenshaw}, kr::AbstractUnitRange, jr::AbstractUnitRange) where T
     m = max(kr.start,jr.start,kr.stop,jr.stop)
     return Symmetric(getindex(S.data,1:m,1:m),Symbol(S.uplo))[kr,jr]
 end

--- a/src/clenshaw.jl
+++ b/src/clenshaw.jl
@@ -306,24 +306,12 @@ end
 
 getindex(M::Clenshaw, k::Int, j::Int) = M[k:k,j][1]
 
-
 function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, j::Integer) where T
-    M = S.data
-    b = bandwidth(M,1)
-    jkr = max(1,min(j,first(kr))-b÷2):max(j,last(kr))+b÷2
-    # relationship between jkr and kr, jr
-    kr2,j2 = kr.-first(jkr).+1,j-first(jkr)+1
-    f = [Zeros{T}(j2-1); one(T); Zeros{T}(length(jkr)-j2)]
-    lmul!(M.p0, clenshaw(M.c, M.A, M.B, M.C, M.X[jkr, jkr], f)[kr2])
+    return Symmetric(getindex(S.data,kr,j),Symbol(S.uplo))
 end
 
 function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, jr::AbstractUnitRange) where T
-    M = S.data
-    b = bandwidth(M,1)
-    jkr = max(1,min(first(jr),first(kr))-b÷2):max(last(jr),last(kr))+b÷2
-    # relationship between jkr and kr, jr
-    kr2,jr2 = kr.-first(jkr).+1,jr.-first(jkr).+1
-    Symmetric(lmul!(M.p0, clenshaw(M.c, M.A, M.B, M.C, M.X[jkr, jkr])[minimum(min(jr2,kr2)):maximum(max(jr2,kr2)),minimum(min(jr2,kr2)):maximum(max(jr2,kr2))]))[kr2,jr2]
+    return Symmetric(getindex(S.data,kr,jr),Symbol(S.uplo))
 end
 
 transposelayout(M::ClenshawLayout) = LazyBandedMatrices.LazyBandedLayout()

--- a/src/clenshaw.jl
+++ b/src/clenshaw.jl
@@ -310,7 +310,7 @@ function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, k::Integer, jr::AbstractUni
     m = max(jr.start,jr.stop,k)
     return Symmetric(getindex(S.data,1:m,1:m),Symbol(S.uplo))[k,jr]
 end
-function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, j::Integer) where T
+function getindex(S::Symmetric{T,<:Clenshaw}, kr::AbstractUnitRange, j::Integer) where T
     m = max(kr.start,kr.stop,j)
     return Symmetric(getindex(S.data,1:m,1:m),Symbol(S.uplo))[kr,j]
 end

--- a/src/clenshaw.jl
+++ b/src/clenshaw.jl
@@ -308,15 +308,15 @@ getindex(M::Clenshaw, k::Int, j::Int) = M[k:k,j][1]
 
 function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, k::Integer, jr::AbstractUnitRange) where T
     m = max(jr.start,jr.stop,k)
-    return Symmetric(getindex(S.data,1:m,1:m),S.uplo)[k,jr]
+    return Symmetric(getindex(S.data,1:m,1:m),Symbol(S.uplo))[k,jr]
 end
 function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, j::Integer) where T
     m = max(kr.start,kr.stop,j)
-    return Symmetric(getindex(S.data,1:m,1:m),S.uplo)[kr,j]
+    return Symmetric(getindex(S.data,1:m,1:m),Symbol(S.uplo))[kr,j]
 end
 function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, jr::AbstractUnitRange) where T
     m = max(kr.start,jr.start,kr.stop,jr.stop)
-    return Symmetric(getindex(S.data,1:m,1:m),S.uplo)[kr,jr]
+    return Symmetric(getindex(S.data,1:m,1:m),Symbol(S.uplo))[kr,jr]
 end
 
 transposelayout(M::ClenshawLayout) = LazyBandedMatrices.LazyBandedLayout()

--- a/src/clenshaw.jl
+++ b/src/clenshaw.jl
@@ -306,14 +306,17 @@ end
 
 getindex(M::Clenshaw, k::Int, j::Int) = M[k:k,j][1]
 
-function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, j::Integer) where T
-    m = max(kr.start,jr.start,kr.stop,jr.stop)
-    return getindex(parent(S),1:m,1:m)[kr,j]
+function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, k::Integer, jr::AbstractUnitRange) where T
+    m = max(jr.start,jr.stop,k)
+    return Symmetric(getindex(S.data,1:m,1:m),S.uplo)[k,jr]
 end
-
+function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, j::Integer) where T
+    m = max(kr.start,kr.stop,j)
+    return Symmetric(getindex(S.data,1:m,1:m),S.uplo)[kr,j]
+end
 function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, jr::AbstractUnitRange) where T
     m = max(kr.start,jr.start,kr.stop,jr.stop)
-    return getindex(S.data,1:m,1:m)[kr,jr]
+    return Symmetric(getindex(S.data,1:m,1:m),S.uplo)[kr,jr]
 end
 
 transposelayout(M::ClenshawLayout) = LazyBandedMatrices.LazyBandedLayout()

--- a/src/clenshaw.jl
+++ b/src/clenshaw.jl
@@ -306,6 +306,26 @@ end
 
 getindex(M::Clenshaw, k::Int, j::Int) = M[k:k,j][1]
 
+
+function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, j::Integer) where T
+    M = S.data
+    b = bandwidth(M,1)
+    jkr=max(1,min(j,first(kr))-b÷2):max(j,last(kr))+b÷2
+    # relationship between jkr and kr, jr
+    kr2,j2 = kr.-first(jkr).+1,j-first(jkr)+1
+    f = [Zeros{T}(j2-1); one(T); Zeros{T}(length(jkr)-j2)]
+    lmul!(M.p0, clenshaw(M.c, M.A, M.B, M.C, M.X[jkr, jkr], f)[kr2])
+end
+
+function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, jr::AbstractUnitRange) where T
+    M = S.data
+    b = bandwidth(M,1)
+    jkr=max(1,min(first(jr),first(kr))-b÷2):max(last(jr),last(kr))+b÷2
+    # relationship between jkr and kr, jr
+    kr2,jr2 = kr.-first(jkr).+1,jr.-first(jkr).+1
+    Symmetric(lmul!(M.p0, clenshaw(M.c, M.A, M.B, M.C, M.X[jkr, jkr])[minimum(min(jr2,kr2)):maximum(max(jr2,kr2)),minimum(min(jr2,kr2)):maximum(max(jr2,kr2))]))[kr2,jr2]
+end
+
 transposelayout(M::ClenshawLayout) = LazyBandedMatrices.LazyBandedLayout()
 # TODO: generalise for layout, use Base.PermutedDimsArray
 Base.permutedims(M::Clenshaw{<:Number}) = transpose(M)

--- a/src/clenshaw.jl
+++ b/src/clenshaw.jl
@@ -307,11 +307,13 @@ end
 getindex(M::Clenshaw, k::Int, j::Int) = M[k:k,j][1]
 
 function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, j::Integer) where T
-    return Symmetric(getindex(S.data,kr,j),Symbol(S.uplo))
+    m = max(kr.start,jr.start,kr.stop,jr.stop)
+    return getindex(parent(S),1:m,1:m)[kr,j]
 end
 
 function getindex(S::Symmetric{T,<:Clenshaw{<:Any}}, kr::AbstractUnitRange, jr::AbstractUnitRange) where T
-    return Symmetric(getindex(S.data,kr,jr),Symbol(S.uplo))
+    m = max(kr.start,jr.start,kr.stop,jr.stop)
+    return getindex(S.data,1:m,1:m)[kr,jr]
 end
 
 transposelayout(M::ClenshawLayout) = LazyBandedMatrices.LazyBandedLayout()

--- a/test/test_choleskyQR.jl
+++ b/test/test_choleskyQR.jl
@@ -2,7 +2,6 @@ using Test, ClassicalOrthogonalPolynomials, BandedMatrices, LinearAlgebra, LazyA
 import ClassicalOrthogonalPolynomials: cholesky_jacobimatrix, qr_jacobimatrix, orthogonalpolynomial
 import LazyArrays: AbstractCachedMatrix, resizedata!
 
-
 @testset "CholeskyQR" begin
     @testset "Comparison of Cholesky with Lanczos and Classical" begin
         @testset "Using Clenshaw for polynomial weights" begin
@@ -28,7 +27,7 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
                 P = Normalized(Legendre()[affine(0..1,Inclusion(-1..1)),:])
                 x = axes(P,1)
                 J = jacobimatrix(P)
-                wf(x) = (1-x^2)
+                wf = x -> (1-x^2)
                 # compute Jacobi matrix via cholesky
                 Jchol = cholesky_jacobimatrix(wf, P)
                 # compute Jacobi matrix via Lanczos
@@ -41,7 +40,7 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
                 P = Normalized(legendre(0..1))
                 x = axes(P,1)
                 J = jacobimatrix(P)
-                wf(x) = (1-x^4)
+                wf = x-> (1-x^4)
                 # compute Jacobi matrix via cholesky
                 Jchol = cholesky_jacobimatrix(wf, P)
                 # compute Jacobi matrix via Lanczos
@@ -54,7 +53,7 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
                 P = Normalized(Legendre()[affine(0..1,Inclusion(-1..1)),:])
                 x = axes(P,1)
                 J = jacobimatrix(P)
-                wf(x) = 1.014-x^4
+                wf = x-> 1.014-x^4
                 # compute Jacobi matrix via cholesky
                 Jchol = cholesky_jacobimatrix(wf, P)
                 # compute Jacobi matrix via Lanczos
@@ -69,7 +68,7 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
                 P = Normalized(Legendre()[affine(0..1,Inclusion(-1..1)),:])
                 x = axes(P,1)
                 J = jacobimatrix(P)
-                wf(x) = exp(x)
+                wf = x-> exp(x)
                 # compute Jacobi matrix via cholesky
                 Jchol = cholesky_jacobimatrix(wf, P)
                 # compute Jacobi matrix via Lanczos
@@ -82,7 +81,7 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
                 P = Normalized(Legendre()[affine(0..1,Inclusion(-1..1)),:])
                 x = axes(P,1)
                 J = jacobimatrix(P)
-                wf(x) = (1-x)*exp(x)
+                wf = x -> (1-x)*exp(x)
                 # compute Jacobi matrix via cholesky
                 Jchol = cholesky_jacobimatrix(wf, P)
                 # compute Jacobi matrix via Lanczos
@@ -95,7 +94,7 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
                 P = Normalized(legendre(0..1))
                 x = axes(P,1)
                 J = jacobimatrix(P)
-                wf(x) = (1-x)^2*exp(x^2)
+                wf = x -> (1-x)^2*exp(x^2)
                 # compute Jacobi matrix via decomp
                 Jchol = cholesky_jacobimatrix(wf, P)
                 # compute Jacobi matrix via Lanczos
@@ -108,7 +107,7 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
                 P = Normalized(Legendre()[affine(0..1,Inclusion(-1..1)),:])
                 x = axes(P,1)
                 J = jacobimatrix(P)
-                wf(x) = x*(1-x^2)*exp(-x^2)
+                wf = x-> x*(1-x^2)*exp(-x^2)
                 # compute Jacobi matrix via cholesky
                 Jchol = cholesky_jacobimatrix(wf, P)
                 # compute Jacobi matrix via Lanczos
@@ -121,12 +120,11 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
                 P = Normalized(legendre(0..1))
                 x = axes(P,1)
                 J = jacobimatrix(P)
-                wf(x) = (1-x)^2
-                sqrtwf(x) = (1-x)
+                wf = x -> (1-x)^2
                 # compute Jacobi matrix via decomp
                 Jchol = cholesky_jacobimatrix(wf, P)
-                JqrQ = qr_jacobimatrix(sqrtwf, P)
-                JqrR = qr_jacobimatrix(sqrtwf, P, :R)
+                JqrQ = qr_jacobimatrix(wf, P)
+                JqrR = qr_jacobimatrix(wf, P, :R)
                 @test (Jchol*Jchol)[1:10,1:10] ≈ ApplyArray(*,Jchol,Jchol)[1:10,1:10]
                 @test (Jchol*Jchol)[1:10,1:10] ≈ (JqrQ*JqrQ)[1:10,1:10]
                 @test (Jchol*Jchol)[1:10,1:10] ≈ (JqrR*JqrR)[1:10,1:10]
@@ -139,12 +137,12 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
             P = Normalized(legendre(0..1))
             x = axes(P,1)
             J = jacobimatrix(P)
-            wf(x) = (1-x)^2
-            sqrtwf(x) = (1-x)
+            wf = x-> (1-x)^2
+            sqrtwf = x-> (1-x)
             # compute Jacobi matrix via decomp
             Jchol = cholesky_jacobimatrix(wf, P)
-            JqrQ = qr_jacobimatrix(sqrtwf, P)
-            JqrR = qr_jacobimatrix(sqrtwf, P, :R)
+            JqrQ = qr_jacobimatrix(wf, P)
+            JqrR = qr_jacobimatrix(wf, P, :R)
             # use alternative inputs
             sqrtW = (P \ (sqrtwf.(x) .* P))
             JqrQalt = qr_jacobimatrix(sqrtW, P)
@@ -162,10 +160,11 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
             P = Normalized(legendre(0..1))
             x = axes(P,1)
             J = jacobimatrix(P)
-            sqrtwf(x) = (1-x)^2
+            wf = x -> (1-x)^4
+            sqrtwf = x -> (1-x)^2
             # compute Jacobi matrix via decomp
-            JqrQ = qr_jacobimatrix(sqrtwf, P)
-            JqrR = qr_jacobimatrix(sqrtwf, P, :R)
+            JqrQ = qr_jacobimatrix(wf, P)
+            JqrR = qr_jacobimatrix(wf, P, :R)
             # use alternative inputs
             sqrtW = (P \ (sqrtwf.(x) .* P))
             JqrQalt = qr_jacobimatrix(sqrtW, P)
@@ -182,10 +181,11 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
             P = Normalized(legendre(0..1))
             x = axes(P,1)
             J = jacobimatrix(P)
-            sqrtwf(x) = (x)*(1-x)^2
+            wf = x-> (x)^2*(1-x)^4
+            sqrtwf = x-> (x)*(1-x)^2
             # compute Jacobi matrix via decomp
-            JqrQ = qr_jacobimatrix(sqrtwf, P)
-            JqrR = qr_jacobimatrix(sqrtwf, P, :R)
+            JqrQ = qr_jacobimatrix(wf, P)
+            JqrR = qr_jacobimatrix(wf, P, :R)
             # use alternative inputs
             sqrtW = (P \ (sqrtwf.(x) .* P))
             JqrQalt = qr_jacobimatrix(sqrtW, P)
@@ -198,7 +198,7 @@ import LazyArrays: AbstractCachedMatrix, resizedata!
             @test JqrQalt[1:10,1:10] ≈ Jclass[1:10,1:10]
             @test JqrRalt[1:10,1:10] ≈ Jclass[1:10,1:10]
             # test consistency of resizing in succession
-            F = qr_jacobimatrix(sqrtwf, P);
+            F = qr_jacobimatrix(wf, P);
             resizedata!(JqrQ.dv,70)
             resizedata!(JqrQ.ev,70)
             @test JqrQ[1:5,1:5] ≈ F[1:5,1:5]

--- a/test/test_normalized.jl
+++ b/test/test_normalized.jl
@@ -78,6 +78,7 @@ import ContinuumArrays: MappedWeightedBasisLayout
 
             # Clenshaw is symmetric for normalized polynomials
             S = Symmetric(W)
+            @test S[2,1:7] ≈ W[2,1:7]
             @test S[1:10,2] ≈ W[1:10,2]
             @test S[1:10,1:10] ≈ W[1:10,1:10]
             @test S[13,15] ≈ W[13,15]

--- a/test/test_normalized.jl
+++ b/test/test_normalized.jl
@@ -75,6 +75,12 @@ import ContinuumArrays: MappedWeightedBasisLayout
             w = @. x + x^2 + 1 # w[x] == x + x^2 + 1
             W = Q \ (w .* Q)
             @test W isa Clenshaw
+
+            # Clenshaw is symmetric for normalized polynomials
+            S = Symmetric(W)
+            @test S[1:10,2] ≈ W[1:10,2]
+            @test S[1:10,1:10] ≈ W[1:10,1:10]
+            @test S[13,15] ≈ W[13,15]
         end
 
         @testset "show" begin


### PR DESCRIPTION
WIP to address https://github.com/JuliaApproximation/ClassicalOrthogonalPolynomials.jl/issues/167. It will also fix some docstring issues.

For now a lot of speed is gained by creating a dedicated method for getindex of `Symmetric{Clenshaw}`, `CholeskyJacobiData` as well as better resizing in `cholesky_jacobimatrix`. 

For low polynomial degree of the weight the method is approaching acceptable speeds again, though even with Symmetric Clenshaw now as fast as regular Clenshaw the Clenshaw evals are still a major bottleneck:
```julia
julia> P = Normalized(Legendre());
julia> x = axes(P,1);
julia> J = jacobimatrix(P);
julia> wf(x) = (2 .+ x.^4);
julia> W = Symmetric(P \ (wf.(x) .* P));
# raw Clenshaw timing
julia> @time W[1:1000,1:1000];
  0.027092 seconds (18 allocations: 485.281 KiB)
# Cholesky X timing
julia> Jchol = cholesky_jacobimatrix(W, P);
julia> @time Jchol[1:1000,1:1000];
  0.061909 seconds (4.57 k allocations: 8.131 MiB)
```

Of course for high polynomial degree this causes major slow downs, although there are clearly also other things to optimize:
```julia
julia> r = 0.5;
julia> lmin, lmax = (1-sqrt(r))^2,  (1+sqrt(r))^2;
julia> P = Normalized(chebyshevu(lmin..lmax));
julia> x = axes(P,1);
julia> J = jacobimatrix(P);
julia> wf(x) = 1/(x*r);
# raw Clenshaw timing
julia> W = Symmetric(P \ (wf.(x) .* P));
julia> @time W[1:1000,1:1000];
  3.562982 seconds (18 allocations: 10.764 MiB)
# Cholesky X timing
julia> Jchol = cholesky_jacobimatrix(W, P);
julia> @time Jchol[1:1000,1:1000];
  5.413114 seconds (4.60 k allocations: 19.039 MiB)
```


Todo list:
- [x] While symmetric and non-symmetric Clenshaw are now equal in speed, Clenshaw evaluation is still very slow which constitutes 50%+ of the compute time spent in `cholesky_jacobimatrix`. 
- [x] Other optimizations and reduce allocations.
- [x] Also make changes for QR method once Cholesky is satisfactory
- [x] Add tests