### PR TITLE
Fix `\` for LanczosPolynomials with empty caches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClassicalOrthogonalPolynomials"
 uuid = "b30e2e7b-c4ee-47da-9d5f-2c5c27239acd"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -91,7 +91,7 @@ Base.BroadcastStyle(::Type{<:LanczosConversion}) = LazyArrays.LazyArrayStyle{2}(
 
 struct LanczosConversionLayout <: AbstractLazyLayout end
 
-_emptymaximum(arr) =  isempty(arr) ? zero(eltype(arr)) : maximum(arr) # only valid for one-based containers
+_emptymaximum(arr) =  isempty(arr) ? convert(eltype(arr), firstindex(arr)-1): maximum(arr) 
 
 LazyArrays.simplifiable(::Mul{LanczosConversionLayout,<:AbstractPaddedLayout}) = Val(true)
 function copy(M::Mul{LanczosConversionLayout,<:AbstractPaddedLayout})

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -91,7 +91,7 @@ Base.BroadcastStyle(::Type{<:LanczosConversion}) = LazyArrays.LazyArrayStyle{2}(
 
 struct LanczosConversionLayout <: AbstractLazyLayout end
 
-_emptymaximum(arr) =  isempty(arr) ? convert(eltype(arr), firstindex(arr)-1): maximum(arr) 
+_emptymaximum(arr) =  isempty(arr) ? convert(eltype(arr), firstindex(arr)-1) : maximum(arr) 
 
 LazyArrays.simplifiable(::Mul{LanczosConversionLayout,<:AbstractPaddedLayout}) = Val(true)
 function copy(M::Mul{LanczosConversionLayout,<:AbstractPaddedLayout})

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -91,14 +91,16 @@ Base.BroadcastStyle(::Type{<:LanczosConversion}) = LazyArrays.LazyArrayStyle{2}(
 
 struct LanczosConversionLayout <: AbstractLazyLayout end
 
+_emptymaximum(arr) =  isempty(arr) ? zero(eltype(arr)) : maximum(arr) # only valid for one-based containers
+
 LazyArrays.simplifiable(::Mul{LanczosConversionLayout,<:AbstractPaddedLayout}) = Val(true)
 function copy(M::Mul{LanczosConversionLayout,<:AbstractPaddedLayout})
-    resizedata!(M.A.data, maximum(colsupport(M.B)))
+    resizedata!(M.A.data, _emptymaximum(colsupport(M.B)))
     M.A.data.R * M.B
 end
 
 function copy(M::Ldiv{LanczosConversionLayout,<:AbstractPaddedLayout})
-    resizedata!(M.A.data, maximum(colsupport(M.B)))
+    resizedata!(M.A.data, _emptymaximum(colsupport(M.B)))
     M.A.data.R \ M.B
 end
 

--- a/test/test_lanczos.jl
+++ b/test/test_lanczos.jl
@@ -1,5 +1,5 @@
 using ClassicalOrthogonalPolynomials, BandedMatrices, ArrayLayouts, QuasiArrays, ContinuumArrays, InfiniteArrays, Test
-import ClassicalOrthogonalPolynomials: recurrencecoefficients, PaddedColumns, orthogonalityweight, golubwelsch, LanczosData
+import ClassicalOrthogonalPolynomials: recurrencecoefficients, PaddedColumns, orthogonalityweight, golubwelsch, LanczosData, _emptymaximum, LanczosConversion
 
 @testset "Lanczos" begin
     @testset "Legendre" begin
@@ -303,4 +303,16 @@ import ClassicalOrthogonalPolynomials: recurrencecoefficients, PaddedColumns, or
         @test jacobimatrix(Q)[1,1] ≈ 1/3
         @test Q[0.5,1:3] ≈ [1, 1.369306393762913, 0.6469364618834543]
     end
+end
+
+@testset "#197" begin
+    @test _emptymaximum(1:5) == 5 
+    @test _emptymaximum(1:0) == 0
+    x = Inclusion(ChebyshevInterval())
+    f = exp.(x)
+    QQ = LanczosPolynomial(f)
+    R = LanczosConversion(QQ.data)
+    v = cache(Zeros(∞))
+    @test (R \ v)[1:500] == zeros(500)
+    @test (R * v)[1:500] == zeros(500)
 end


### PR DESCRIPTION
Fixes #197 

(This issue comes up when trying to expand identically zero functions with SemiclassicalOrthogonalPolynomials.jl)