### PR TITLE
fix an inexact error

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -233,6 +233,9 @@ ClassicalOrthogonalPolynomials.WeightedOPLayout
 ClassicalOrthogonalPolynomials.interlace!
 ```
 ```@docs
+ClassicalOrthogonalPolynomials._approx_integer
+```
+```@docs
 ClassicalOrthogonalPolynomials._tritrunc
 ```
 ```@docs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -233,9 +233,6 @@ ClassicalOrthogonalPolynomials.WeightedOPLayout
 ClassicalOrthogonalPolynomials.interlace!
 ```
 ```@docs
-ClassicalOrthogonalPolynomials._approx_integer
-```
-```@docs
 ClassicalOrthogonalPolynomials._tritrunc
 ```
 ```@docs

--- a/src/classical/jacobi.jl
+++ b/src/classical/jacobi.jl
@@ -312,12 +312,25 @@ function _jacobi_convert_b(a, b, k, T) # Jacobi(a, b+k) \ Jacobi(a, b)
     end
 end
 
+"""
+    _approx_integer(x; kw...)
+
+Returns `y::Integer` such that `isapprox(x,y; kw...)` is `true`. Throws `InexactError` if `y` does not exist.
+"""
+function _approx_integer(x; kw...)
+    y = round(x)
+    if !isapprox(x,y; kw...)
+        throw(InexactError(_approx_integer, x))
+    end
+    Integer(y)
+end
+
 function \(A::Jacobi, B::Jacobi)
     T = promote_type(eltype(A), eltype(B))
     aa, ab = A.a, A.b
     ba, bb = B.a, B.b
-    ka = Integer(aa-ba)
-    kb = Integer(ab-bb)
+    ka = _approx_integer(aa-ba)
+    kb = _approx_integer(ab-bb)
     if ka >= 0
         C1 = _jacobi_convert_a(ba, ab, ka, T)
         if kb >= 0

--- a/src/classical/jacobi.jl
+++ b/src/classical/jacobi.jl
@@ -122,6 +122,7 @@ OrthogonalPolynomial(w::JacobiWeight) = Jacobi(w.a, w.b)
 orthogonalityweight(P::Jacobi) = JacobiWeight(P.a, P.b)
 
 const WeightedJacobi{T} = WeightedBasis{T,<:JacobiWeight,<:Jacobi}
+WeightedJacobi(P::Jacobi{T}) where T = JacobiWeight(zero(T),zero(T)) .* P
 
 """
     HalfWeighted{lr}(Jacobi(a,b))
@@ -320,16 +321,8 @@ function \(A::Jacobi, B::Jacobi)
     end
 end
 
-function \(A::Jacobi, w_B::WeightedJacobi)
-    a,b = A.a,A.b
-    (JacobiWeight(zero(a),zero(b)) .* A) \ w_B
-end
-
-function \(w_A::WeightedJacobi, B::Jacobi)
-    a,b = B.a,B.b
-    w_A \ (JacobiWeight(zero(a),zero(b)) .* B)
-end
-
+\(A::Jacobi, w_B::WeightedJacobi) = WeightedJacobi(A) \ w_B
+\(w_A::WeightedJacobi, B::Jacobi) = w_A \ WeightedJacobi(B)
 \(A::AbstractJacobi, w_B::WeightedJacobi) = Jacobi(A) \ w_B
 \(w_A::WeightedJacobi, B::AbstractJacobi) = w_A \ Jacobi(B)
 

--- a/src/classical/jacobi.jl
+++ b/src/classical/jacobi.jl
@@ -295,13 +295,17 @@ end
 
 function _jacobi_convert_a(a, b, k, T) # Jacobi(a+k, b) \ Jacobi(a, b)
     j = round(k)
-    @assert j ≈ k
+    if j ≉ k
+        throw(ArgumentError("non-integer conversions not supported"))
+    end
     k = Integer(j)
     reduce(*, [_jacobi_convert_a(a+j, b) for j in k-1:-1:0], init=Eye{T}(∞))
 end
 function _jacobi_convert_b(a, b, k, T) # Jacobi(a, b+k) \ Jacobi(a, b)
     j = round(k)
-    @assert j ≈ k
+    if j ≉ k
+        throw(ArgumentError("non-integer conversions not supported"))
+    end
     k = Integer(j)
     reduce(*, [_jacobi_convert_b(a, b+j) for j in k-1:-1:0], init=Eye{T}(∞))
 end

--- a/src/classical/jacobi.jl
+++ b/src/classical/jacobi.jl
@@ -318,19 +318,6 @@ function _jacobi_convert_b(a, b, k, T) # Jacobi(a, b+k) \ Jacobi(a, b)
     end
 end
 
-"""
-    _approx_integer(x; kw...)
-
-Returns `y::Integer` such that `isapprox(x,y; kw...)` is `true`. Throws `InexactError` if `y` does not exist.
-"""
-function _approx_integer(x; kw...)
-    y = round(x)
-    if !isapprox(x,y; kw...)
-        throw(InexactError(_approx_integer, x))
-    end
-    Integer(y)
-end
-
 function \(A::Jacobi, B::Jacobi)
     T = promote_type(eltype(A), eltype(B))
     aa, ab = A.a, A.b

--- a/src/classical/jacobi.jl
+++ b/src/classical/jacobi.jl
@@ -292,6 +292,9 @@ end
 # the type specification is also because LazyArrays.jl is slow otherwise
 # getindex and print could be very slow. This needs to be fixed by LazyArrays.jl
 function _jacobi_convert_a(a, b, k, T) # Jacobi(a+k, b) \ Jacobi(a, b)
+    j = round(k)
+    @assert j ≈ k
+    k = Integer(j)
     if iszero(k)
         Eye{T}(∞)
     elseif isone(k)
@@ -302,6 +305,9 @@ function _jacobi_convert_a(a, b, k, T) # Jacobi(a+k, b) \ Jacobi(a, b)
     end
 end
 function _jacobi_convert_b(a, b, k, T) # Jacobi(a, b+k) \ Jacobi(a, b)
+    j = round(k)
+    @assert j ≈ k
+    k = Integer(j)
     if iszero(k)
         Eye{T}(∞)
     elseif isone(k)
@@ -329,8 +335,8 @@ function \(A::Jacobi, B::Jacobi)
     T = promote_type(eltype(A), eltype(B))
     aa, ab = A.a, A.b
     ba, bb = B.a, B.b
-    ka = _approx_integer(aa-ba)
-    kb = _approx_integer(ab-bb)
+    ka = aa - ba
+    kb = ab - bb
     if ka >= 0
         C1 = _jacobi_convert_a(ba, ab, ka, T)
         if kb >= 0
@@ -345,6 +351,7 @@ function \(A::Jacobi, B::Jacobi)
         else
             list = (C1, C2)
             ApplyArray{T,2,typeof(*),typeof(list)}(*, list)
+            C1 * C2
         end
     else
         inv(B \ A)

--- a/test/test_jacobi.jl
+++ b/test/test_jacobi.jl
@@ -147,6 +147,9 @@ import ClassicalOrthogonalPolynomials: recurrencecoefficients, basis, MulQuasiMa
             # special weighted conversions
             W = (JacobiWeight(-1,-1) .* Jacobi(0,0)) \ Jacobi(0,0)
             @test ((JacobiWeight(-1,-1) .* Jacobi(0,0)) * W)[0.1,1:10] ≈ Jacobi(0,0)[0.1,1:10]
+
+            # potential inexact errors
+            Jacobi(1.9,1.9) \ Jacobi(0.9,0.9) # isinteger(1.9-0.9) = false
         end
 
         @testset "Derivative" begin


### PR DESCRIPTION
This bug was introduced by the overhaul of Jacobi connection #145 , which basically replaced `≈` with `==`.

```julia
julia> Integer(1.9-0.9)
ERROR: InexactError: Int64(0.9999999999999999)
Stacktrace:
 [1] Int64
   @ .\float.jl:994 [inlined]
 [2] Integer(x::Float64)
   @ Core .\boot.jl:926
 [3] top-level scope
   @ REPL[5]:1
```

also simplified some codes, particularly those introduced by #145 .

Edit: #211 conflicts with this... Apart from other code simplifications, `isapproxinteger` requires multiple computation of `k`. This PR reduces the computation to only once and also let the lower level handle the errors.