### PR TITLE
Support DynamicPolynomials.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClassicalOrthogonalPolynomials"
 uuid = "b30e2e7b-c4ee-47da-9d5f-2c5c27239acd"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.13.7"
+version = "0.13.8"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -26,6 +26,12 @@ RecurrenceRelationships = "807425ed-42ea-44d6-a357-6771516d7b2c"
 RecurrenceRelationshipArrays = "b889d2dc-af3c-4820-88a8-238fa91d3518"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
+[weakdeps]
+MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
+
+[extensions]
+ClassicalOrthogonalPolynomialsMutableArithmeticsExt = "MutableArithmetics"
+
 [compat]
 ArrayLayouts = "1.3.1"
 BandedMatrices = "1"
@@ -33,6 +39,7 @@ BlockArrays = "1"
 BlockBandedMatrices = "0.13"
 ContinuumArrays = "0.18.3"
 DomainSets = "0.6, 0.7"
+DynamicPolynomials = "0.6"
 FFTW = "1.1"
 FastGaussQuadrature = "1"
 FastTransforms = "0.16.6"
@@ -43,6 +50,7 @@ InfiniteLinearAlgebra = "0.8"
 IntervalSets = "0.7"
 LazyArrays = "2.2"
 LazyBandedMatrices = "0.10"
+MutableArithmetics = "1"
 QuasiArrays = "0.11"
 RecurrenceRelationships = "0.1"
 RecurrenceRelationshipArrays = "0.1"
@@ -51,6 +59,7 @@ julia = "1.10"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SemiseparableMatrices = "f8ebbe35-cbfb-4060-bf7f-b10e4670cf57"
@@ -58,4 +67,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Base64", "Test", "ForwardDiff", "SemiseparableMatrices", "StaticArrays", "Random"]
+test = ["Base64", "Test", "ForwardDiff", "SemiseparableMatrices", "StaticArrays", "Random", "DynamicPolynomials"]

--- a/ext/ClassicalOrthogonalPolynomialsMutableArithmeticsExt.jl
+++ b/ext/ClassicalOrthogonalPolynomialsMutableArithmeticsExt.jl
@@ -1,7 +1,8 @@
 module ClassicalOrthogonalPolynomialsMutableArithmeticsExt
 using ClassicalOrthogonalPolynomials, MutableArithmetics
-using ClassicalOrthogonalPolynomials: initiateforwardrecurrence, recurrencecoefficients, _p0
+import ClassicalOrthogonalPolynomials: initiateforwardrecurrence, recurrencecoefficients, _p0
 
 Base.unsafe_getindex(P::OrthogonalPolynomial, x::AbstractMutable, n::Number) = initiateforwardrecurrence(n-1, recurrencecoefficients(P)..., x, _p0(P))[end]
 
+recurrencecoefficients(::Legendre{T}) where T<:AbstractMutable = recurrencecoefficients(Legendre())
 end

--- a/ext/ClassicalOrthogonalPolynomialsMutableArithmeticsExt.jl
+++ b/ext/ClassicalOrthogonalPolynomialsMutableArithmeticsExt.jl
@@ -1,0 +1,7 @@
+module ClassicalOrthogonalPolynomialsMutableArithmeticsExt
+using ClassicalOrthogonalPolynomials, MutableArithmetics
+using ClassicalOrthogonalPolynomials: initiateforwardrecurrence, recurrencecoefficients, _p0
+
+Base.unsafe_getindex(P::OrthogonalPolynomial, x::AbstractMutable, n::Number) = initiateforwardrecurrence(n-1, recurrencecoefficients(P)..., x, _p0(P))[end]
+
+end

--- a/src/classical/chebyshev.jl
+++ b/src/classical/chebyshev.jl
@@ -61,13 +61,13 @@ chebyshevu(S::AbstractQuasiMatrix) = chebyshevu(axes(S,1))
 
 computes the `n`-th Chebyshev polynomial of the first kind at `z`.
 """
-chebyshevt(n::Integer, z::Number) = Base.unsafe_getindex(ChebyshevT{typeof(z)}(), z, n+1)
+chebyshevt(n::Integer, z) = Base.unsafe_getindex(ChebyshevT{typeof(z)}(), z, n+1)
 """
      chebyshevt(n, z)
 
 computes the `n`-th Chebyshev polynomial of the second kind at `z`.
 """
-chebyshevu(n::Integer, z::Number) = Base.unsafe_getindex(ChebyshevU{typeof(z)}(), z, n+1)
+chebyshevu(n::Integer, z) = Base.unsafe_getindex(ChebyshevU{typeof(z)}(), z, n+1)
 
 chebysevtweight(d::AbstractInterval{T}) where T = ChebyshevTWeight{float(T)}[affine(d,ChebyshevInterval{T}())]
 chebysevuweight(d::AbstractInterval{T}) where T = ChebyshevUWeight{float(T)}[affine(d,ChebyshevInterval{T}())]

--- a/src/classical/hermite.jl
+++ b/src/classical/hermite.jl
@@ -46,7 +46,7 @@ axes(::Hermite{T}) where T = (Inclusion{T}(ℝ), oneto(∞))
 computes the `n`-th Hermite polynomial, orthogonal with 
 respec to `exp(-x^2)`, at `z`.
 """
-hermiteh(n::Integer, z::Number) = Base.unsafe_getindex(Hermite{typeof(z)}(), z, n+1)
+hermiteh(n::Integer, z) = Base.unsafe_getindex(Hermite{typeof(z)}(), z, n+1)
 
 broadcasted(::LazyQuasiArrayStyle{2}, ::typeof(*), ::HermiteWeight{T}, ::Hermite{V}) where {T,V} = Weighted(Hermite{promote_type(T,V)}())
 
@@ -54,7 +54,7 @@ broadcasted(::LazyQuasiArrayStyle{2}, ::typeof(*), ::HermiteWeight{T}, ::Hermite
 # 1/2 * H_{n+1} + n H_{n-1} = x H_n 
 # x*[H_0 H_1 H_2 …] = [H_0 H_1 H_2 …] * [0    1; 1/2  0     2; 1/2   0  3; …]   
 jacobimatrix(H::Hermite{T}) where T = Tridiagonal(Fill(one(T)/2,∞), Zeros{T}(∞), one(T):∞)
-recurrencecoefficients(H::Hermite{T}) where T = Fill{T}(2,∞), Zeros{T}(∞), zero(T):2:∞
+recurrencecoefficients(H::Hermite) where T = Fill(2,∞), Zeros{Int}(∞), 0:2:∞
 
 weightedgrammatrix(::Hermite{T}) where T = Diagonal(sqrt(convert(T,π)) .* convert(T,2) .^ (0:∞) .* gamma.(one(T):∞))
 

--- a/src/classical/hermite.jl
+++ b/src/classical/hermite.jl
@@ -54,7 +54,7 @@ broadcasted(::LazyQuasiArrayStyle{2}, ::typeof(*), ::HermiteWeight{T}, ::Hermite
 # 1/2 * H_{n+1} + n H_{n-1} = x H_n 
 # x*[H_0 H_1 H_2 …] = [H_0 H_1 H_2 …] * [0    1; 1/2  0     2; 1/2   0  3; …]   
 jacobimatrix(H::Hermite{T}) where T = Tridiagonal(Fill(one(T)/2,∞), Zeros{T}(∞), one(T):∞)
-recurrencecoefficients(H::Hermite) where T = Fill(2,∞), Zeros{Int}(∞), 0:2:∞
+recurrencecoefficients(H::Hermite) = Fill(2,∞), Zeros{Int}(∞), 0:2:∞
 
 weightedgrammatrix(::Hermite{T}) where T = Diagonal(sqrt(convert(T,π)) .* convert(T,2) .^ (0:∞) .* gamma.(one(T):∞))
 

--- a/src/classical/jacobi.jl
+++ b/src/classical/jacobi.jl
@@ -119,8 +119,8 @@ basis_singularities(w::JacobiWeight) = Weighted(Jacobi(w.a, w.b))
 computes the `n`-th Jacobi polynomial, orthogonal with
 respec to `(1-x)^a*(1+x)^b`, at `z`.
 """
-jacobip(n::Integer, a, b, z::Number) = Base.unsafe_getindex(Jacobi{promote_type(typeof(a), typeof(b), typeof(z))}(a,b), z, n+1)
-normalizedjacobip(n::Integer, a, b, z::Number) = Base.unsafe_getindex(Normalized(Jacobi{promote_type(typeof(a), typeof(b), typeof(z))}(a,b)), z, n+1)
+jacobip(n::Integer, a, b, z) = Base.unsafe_getindex(Jacobi{promote_type(typeof(a), typeof(b), typeof(z))}(a,b), z, n+1)
+normalizedjacobip(n::Integer, a, b, z) = Base.unsafe_getindex(Normalized(Jacobi{promote_type(typeof(a), typeof(b), typeof(z))}(a,b)), z, n+1)
 
 OrthogonalPolynomial(w::JacobiWeight) = Jacobi(w.a, w.b)
 orthogonalityweight(P::Jacobi) = JacobiWeight(P.a, P.b)

--- a/src/classical/legendre.jl
+++ b/src/classical/legendre.jl
@@ -67,7 +67,7 @@ legendre(d::Inclusion) = legendre(d.domain)
 
 computes the `n`-th Legendre polynomial at `z`.
 """
-legendrep(n::Integer, z::Number) = Base.unsafe_getindex(Legendre{typeof(z)}(), z, n+1)
+legendrep(n::Integer, z) = Base.unsafe_getindex(Legendre{typeof(z)}(), z, n+1)
 
 
 show(io::IO, w::Legendre{Float64}) = summary(io, w)

--- a/src/classical/ultraspherical.jl
+++ b/src/classical/ultraspherical.jl
@@ -54,7 +54,7 @@ const WeightedUltraspherical{T} = WeightedBasis{T,<:UltrasphericalWeight,<:Ultra
 
 orthogonalityweight(C::Ultraspherical) = UltrasphericalWeight(C.λ)
 
-ultrasphericalc(n::Integer, λ, z::Number) = Base.unsafe_getindex(Ultraspherical{promote_type(typeof(λ),typeof(z))}(λ), z, n+1)
+ultrasphericalc(n::Integer, λ, z) = Base.unsafe_getindex(Ultraspherical{promote_type(typeof(λ),typeof(z))}(λ), z, n+1)
 ultraspherical(λ, d::AbstractInterval{T}) where T = Ultraspherical{float(promote_type(eltype(λ),T))}(λ)[affine(d,ChebyshevInterval{T}()), :]
 
 ==(a::Ultraspherical, b::Ultraspherical) = a.λ == b.λ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,3 +86,5 @@ end
     @test startswith(sprint(show, MIME"text/plain"(), Chebyshev()[0.3, :]; context=(:compact=>true, :limit=>true)), "ℵ₀-element view(::ChebyshevT{Float64}, 0.3, :)")
     @test startswith(sprint(show, MIME"text/plain"(), Jacobi(0.2, 0.5)[-0.7, :]; context=(:compact=>true, :limit=>true)), "ℵ₀-element view(::Jacobi{Float64}, -0.7, :)")
 end
+
+include("test_dynamicpolynomials.jl")

--- a/test/test_dynamicpolynomials.jl
+++ b/test/test_dynamicpolynomials.jl
@@ -1,0 +1,11 @@
+using DynamicPolynomials, ClassicalOrthogonalPolynomials, Test
+
+@polyvar x
+
+@testset "DynamicPolynomials" begin
+    @test chebyshevt(0,x) == 1
+    @test chebyshevt(1,x) == x
+    @test chebyshevt(5,x) == 5x - 20x^3 + 16x^5
+    @test chebyshevu(5,x) == 6x - 32x^3 + 32x^5
+    legendrep(5,x)
+end

--- a/test/test_dynamicpolynomials.jl
+++ b/test/test_dynamicpolynomials.jl
@@ -6,6 +6,7 @@ using DynamicPolynomials, ClassicalOrthogonalPolynomials, Test
     @test chebyshevt(0,x) == 1
     @test chebyshevt(1,x) == x
     @test chebyshevt(5,x) == 5x - 20x^3 + 16x^5
-    @test chebyshevu(5,x) == 6x - 32x^3 + 32x^5
-    legendrep(5,x)
+    @test chebyshevu(5,x) == ultrasphericalc(5,1,x) == 6x - 32x^3 + 32x^5
+    @test legendrep(5,x) ≈ (15x - 70x^3 + 63x^5)/8
+    @test hermiteh(5,x) == 120x - 160x^3 + 32x^5
 end


### PR DESCRIPTION
This supports combining this package with symbolic computation. It's surprisingly fast! 3.5x faster than mathematica in fact:
```julia
julia> @time chebyshevt(10_000,x)
  0.078005 seconds (3.84 M allocations: 141.068 MiB, 18.68% gc time)
1 - 50000000x² + 416666650000000x⁴ - 5382805582903628800x⁶ - 2295839942961001984x⁸ - 5881664067181658112x¹⁰ + 9071434676160905216x¹² + 2726131615473205248x¹⁴ - 8311353073181097984x¹⁶ - 7478286491391623168x¹⁸ - 6167377969439309824x²⁰ - 749395590768492544x²² - 3810475745168326656x²⁴ + 5035205751279190016x²⁶ + 5745040218969341952x²⁸ - 5921272124512665600x³⁰ + 3935048435299778560x³² + 5526248795295186944x³⁴ - 4574133298292326400x³⁶ + 379621782652452864x³⁸ - 7095975366782615552x⁴⁰ - 9126263169889599488x⁴² - 5118059501529858048x⁴⁴ + 6924284427082137600x⁴⁶ + 7205196453839372288x⁴⁸ + 1729382256910270464x⁵⁰ + 2882303761517117440x⁵² - 4611686018427387904x⁵⁴ + 6917529027641081856x⁵⁶
```