### PR TITLE
Add intervals/weights to the definitions in the docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClassicalOrthogonalPolynomials"
 uuid = "b30e2e7b-c4ee-47da-9d5f-2c5c27239acd"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,12 +10,12 @@ CurrentModule = ClassicalOrthogonalPolynomials
 We follow the [Digital Library of Mathematical Functions](https://dlmf.nist.gov/18.3),
 which defines the following classical orthogonal polynomials:
 
-1. Legendre: `P_n(x)`
-2. Chebyshev (1st kind, 2nd kind): `T_n(x)`, `U_n(x)`
-3. Ultraspherical: `C_n^{(λ)}(x)`
-4. Jacobi: `P_n^{(a,b)}(x)`
-5. Laguerre: `L_n^{(α)}(x)`
-6. Hermite: `H_n(x)`
+1. Legendre: $P_n(x)$, defined over $[-1, 1]$ with weight $w(x) = 1$.
+2. Chebyshev (1st kind, 2nd kind): $T_n(x)$ and $U_n(x)$, defined over $[-1, 1]$ with weights $w(x) = 1/\sqrt{1-x^2}$ and $w(x) = \sqrt{1-x^2}$, respectively.
+3. Ultraspherical: $C_n^{(\lambda)}(x)$, defined over $[-1, 1]$ with weight $w(x) = (1-x^2)^{\lambda-1/2}$.
+4. Jacobi: $P_n^{(a,b)}(x)$, defined over $[-1, 1]$ with weight $w(x) = (1-x)^a(1+x)^b$.
+5. Laguerre: $L_n^{(\alpha)}(x)$, defined over $[0, ∞)$ with weight $w(x) = x^\alpha \mathrm{e}^{-x}$.
+6. Hermite: $H_n(x)$, defined over $(-∞, ∞)$ with weight $w(x) = \mathrm{e}^{-x^2}$.
 
 ## Evaluation
 


### PR DESCRIPTION
Adds the intervals and weights to the definitions in the docs. Might be useful as a complement to #219 for a quick reference without needing to go to DLMF/18.3?